### PR TITLE
docs: sync main branch ruleset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,17 @@ Use this repository for:
 - service metadata
 - contracts and interpretation context
 
+## Main Branch Contract
+
+This repository is public and its `main` branch is protected by the GitHub
+ruleset `CLEVER protect main`.
+
+- Do not push directly to `main`.
+- Use a role-prefixed branch for repository changes.
+- Open a PR into `main`.
+- `main` PRs require at least one approval.
+- Admin bypass is allowed only in `pull_request` mode.
+
 Do not treat this repository as:
 
 - the default generic startup surface

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ agent는 하나의 실행자다. global과 local은 agent 종류가 아니라 �
 
 ## main 브랜치 운영 규칙
 
-현재 private repo에서는 GitHub branch protection과 rulesets가 막혀 있어 `main` 브랜치를 수기 PR 정책으로 운영한다. 기본값은 direct push 금지, 최소 1회 리뷰 확인, 예외 시 change id와 사유 기록이다. 상세 기준은 `docs/root/pipeline-governance.md`를 따른다.
+이 repo는 public으로 운영하며, `main`은 GitHub ruleset `CLEVER protect main`으로 보호한다.
+기본값은 direct push 금지, PR 필수, 최소 1명 승인이다.
+admin bypass는 `pull_request` 모드만 허용한다.
+상세 기준은 `docs/root/pipeline-governance.md`를 따른다.
 
 ## clever-change-control과의 관계
 

--- a/docs/root/pipeline-governance.md
+++ b/docs/root/pipeline-governance.md
@@ -13,13 +13,15 @@
 - spec, ui-spec, contracts, service docs가 맞지 않으면 구현을 진행하지 않는다.
 - 파이프라인별 세부 설정값은 서비스 문서에서 관리한다.
 
-## main 브랜치 임시 운영 규칙
+## main 브랜치 운영 규칙
 
-- 현재 private repo에서는 GitHub branch protection과 rulesets를 사용할 수 없다고 확인했다.
-- 그 전까지 `main` 직접 푸시는 원칙적으로 금지하고 PR 경유를 기본값으로 운영한다.
-- `main`에 머지하려면 최소 1명의 리뷰 확인을 남긴다.
-- 긴급 예외 머지가 필요하면 change id와 사유를 PR 또는 issue에 같이 남긴다.
-- 플랜 업그레이드나 공개 전환이 가능해지면 이 임시 규칙을 GitHub 보호 규칙으로 치환한다.
+- 이 repo는 public으로 운영한다.
+- `main`은 GitHub ruleset `CLEVER protect main`으로 보호한다.
+- `main` direct push, branch deletion, force push는 금지한다.
+- `main` 변경은 PR로만 올린다.
+- `main` PR은 최소 1명의 승인이 필요하다.
+- admin bypass는 `pull_request` 모드만 허용한다.
+- 긴급 변경도 PR 안에 change id와 사유를 남긴다.
 
 ## 제외
 


### PR DESCRIPTION
## change id

- not-issued: control-plane ruleset sync and PR flow verification

## 관련 issue

- none

## 대상 repo/service

- `clever-context-monorepo`
- control-plane canonical context documentation

## 변경 내용

- Replace obsolete private/manual `main` branch language with the current public GitHub ruleset policy.
- Add the `main` branch contract to `AGENTS.md`.
- Keep doc-governance PR review completion behavior unchanged.

## companion PRs

- https://github.com/EVNSolution/clever-agent-project/pull/3
- https://github.com/EVNSolution/clever-change-control/pull/14

## 테스트 여부

- `git push origin HEAD:main` rejected with `GH013` and `Changes must be made through a pull request`.
- `git diff --check`

## 검수 포인트

- Branch name uses the role prefix `docs/`.
- `main` direct push is blocked.
- PR body carries the review-agent completion fields.

## rollout/rollback 영향

- docs only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `README.md`, `AGENTS.md`, `docs/root/pipeline-governance.md`, `docs/root/doc-governance.md`, `.github/PULL_REQUEST_TEMPLATE.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: this PR updates the canonical context repo directly
- linked issue close evidence: no linked issue for this ruleset smoke test
