### PR TITLE
docs: set main PR approvals to zero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ ruleset `CLEVER protect main`.
 - Do not push directly to `main`.
 - Use a role-prefixed branch for repository changes.
 - Open a PR into `main`.
-- `main` PRs require at least one approval.
+- `main` requires a PR but does not require approving reviews.
+- Merge/write access is limited to repository admins.
 - Admin bypass is allowed only in `pull_request` mode.
 
 Do not treat this repository as:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ agent는 하나의 실행자다. global과 local은 agent 종류가 아니라 �
 ## main 브랜치 운영 규칙
 
 이 repo는 public으로 운영하며, `main`은 GitHub ruleset `CLEVER protect main`으로 보호한다.
-기본값은 direct push 금지, PR 필수, 최소 1명 승인이다.
+기본값은 direct push 금지, PR 필수, 승인 수 0명이다.
+merge/write는 repo admin 권한자만 수행한다.
 admin bypass는 `pull_request` 모드만 허용한다.
 상세 기준은 `docs/root/pipeline-governance.md`를 따른다.
 

--- a/docs/root/pipeline-governance.md
+++ b/docs/root/pipeline-governance.md
@@ -19,7 +19,8 @@
 - `main`은 GitHub ruleset `CLEVER protect main`으로 보호한다.
 - `main` direct push, branch deletion, force push는 금지한다.
 - `main` 변경은 PR로만 올린다.
-- `main` PR은 최소 1명의 승인이 필요하다.
+- `main` PR의 필수 승인 수는 0명이다.
+- merge/write는 repo admin 권한자만 수행한다.
 - admin bypass는 `pull_request` 모드만 허용한다.
 - 긴급 변경도 PR 안에 change id와 사유를 남긴다.
 


### PR DESCRIPTION
## change id

- not-issued: control-plane ruleset operation update

## 관련 issue

- none

## 대상 repo/service

- `clever-context-monorepo`
- control-plane canonical context documentation

## 변경 내용

- Update the canonical `main` branch policy from one required reviewer to zero required approving reviews.
- Keep PR-required, direct-push-blocked, admin-only merge/write operating language.

## companion PRs

- https://github.com/EVNSolution/clever-agent-project/pull/4
- https://github.com/EVNSolution/clever-change-control/pull/15

## 테스트 여부

- `git diff --check`
- remote ruleset check -> `required_approving_review_count: 0`

## 검수 포인트

- `main` still requires PR.
- Required approving reviewers is 0.
- Repo access is constrained by admin/write permissions, not self-review.

## rollout/rollback 영향

- docs only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `README.md`, `AGENTS.md`, `docs/root/pipeline-governance.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: this PR updates the canonical context repo directly
- linked issue close evidence: no linked issue for this ruleset operation update
