### PR TITLE
docs: add PR merge title standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,21 @@ ruleset `CLEVER protect main`.
 - Merge/write access is limited to repository admins.
 - Admin bypass is allowed only in `pull_request` mode.
 
+## PR Merge Commit Title Contract
+
+When merging a PR into `main`, make the resulting main commit visibly PR-based.
+Use squash merge and set the merge subject explicitly:
+
+```bash
+gh pr merge <pr-number> --squash \
+  --subject "PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>" \
+  --body-file <merge-body-file>
+```
+
+Merge body should include the merge summary, validation evidence, and
+wiki/service context update result. Do not use a plain feature/doc commit title
+as the main merge commit subject.
+
 Do not treat this repository as:
 
 - the default generic startup surface

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ merge/write는 repo admin 권한자만 수행한다.
 admin bypass는 `pull_request` 모드만 허용한다.
 상세 기준은 `docs/root/pipeline-governance.md`를 따른다.
 
+`main` merge commit 제목은 PR merge임이 드러나게 아래 형식을 쓴다.
+
+```text
+PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>
+```
+
 ## clever-change-control과의 관계
 
 `clever-change-control`은 변경 요청, 승인, rollout/rollback 흐름을 관리한다. 이 저장소는 그 흐름에서 참조하는 정본 문맥, 규칙, 용어, 계약을 관리한다.

--- a/docs/root/pipeline-governance.md
+++ b/docs/root/pipeline-governance.md
@@ -24,6 +24,26 @@
 - admin bypass는 `pull_request` 모드만 허용한다.
 - 긴급 변경도 PR 안에 change id와 사유를 남긴다.
 
+## PR merge commit 제목 규칙
+
+`main`에 들어가는 merge commit 제목은 PR merge임이 바로 보이게 만든다.
+기본 형식은 아래다.
+
+```text
+PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>
+```
+
+에이전트가 merge할 때는 squash merge subject를 명시한다.
+
+```bash
+gh pr merge <pr-number> --squash \
+  --subject "PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>" \
+  --body-file <merge-body-file>
+```
+
+merge body에는 merge summary, validation evidence, wiki/service context update result를 남긴다.
+일반 작업 commit 제목을 그대로 main merge commit 제목으로 쓰지 않는다.
+
 ## 제외
 
 - 서버 배포 절차 상세


### PR DESCRIPTION
## change id

- not-issued: control-plane merge title standard

## 관련 issue

- none

## 대상 repo/service

- `clever-context-monorepo`
- control-plane canonical context documentation

## 변경 내용

- Add the PR merge commit title contract.
- Standardize main merge subject format as `PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>`.
- Document merge body requirements.

## companion PRs

- https://github.com/EVNSolution/clever-agent-project/pull/5
- https://github.com/EVNSolution/clever-change-control/pull/16

## 테스트 여부

- `git diff --check`

## 검수 포인트

- Main merge commit should visibly look like a PR merge.
- The merge subject should include repo and PR number.

## rollout/rollback 영향

- docs only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `AGENTS.md`, `README.md`, `docs/root/pipeline-governance.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: this PR updates the canonical context repo directly
- linked issue close evidence: no linked issue for this merge-title standard update
