### PR TITLE
docs: rename deploy template to OIDC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,19 +27,24 @@ CLEVER expects a local three-repository workspace:
 2. `clever-context-monorepo`
 3. `clever-change-control`
 
-Before doing real work, run the automatic workspace check from the current session:
+Before doing real work, run the automatic preflight check from the current session:
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 If the session is explicitly about editing this repository itself, run:
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
-Interpret `agent_action` like this:
+The preflight must verify `gh auth status`, GitHub login `OziinG`,
+`EVNSolution` org membership, control-plane remotes, clean worktrees, remote
+fetch access, and issue/PR/ruleset read access. If `preflight_check.ready` is
+false, stop before startup work and report the failed checks.
+
+If it is true, interpret `workspace_check.agent_action` like this:
 
 - `proceed-with-hard-gate`: the workspace is complete and startup may continue
 - `current-repo-maintenance`: this repository itself is the target, so stay here

--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@
 - 작업 라인과 대상 저장소가 아직 정해지지 않은 일반 시작: `clever-agent-project`
 - 현재 `clever-context-monorepo` 자체를 수정하는 작업: 여기서 계속
 
-시작 전에 먼저 아래 명령으로 로컬 3저장소 상태를 확인한다.
+시작 전에 먼저 아래 명령으로 로컬 3저장소, `gh auth status`, GitHub 계정, org membership, 원격 접근, issue/PR/ruleset 조회 가능 여부를 확인한다.
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 현재 저장소 자체를 직접 수정하는 작업이면 아래처럼 유지보수 모드로 확인한다.
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
-결과는 아래처럼 해석한다.
+`preflight_check.ready=false`이면 시작 절차로 내려가지 않고 실패한 check를 먼저 해결한다.
+`true`이면 내부 `workspace_check.agent_action`을 아래처럼 해석한다.
 
 - `proceed-with-hard-gate`: 로컬 상태가 정상이며 시작 절차를 진행할 수 있음
 - `current-repo-maintenance`: 현재 저장소 자체를 수정하는 세션이므로 여기서 계속

--- a/docs/root/agent-runtime-governance.md
+++ b/docs/root/agent-runtime-governance.md
@@ -9,6 +9,28 @@
 
 에이전트는 아래 두 모드를 구분한다.
 
+## Preflight Gate
+
+작업 시작 질문, `project-start` 초안, repo bootstrap, team-work automation으로 내려가기 전에는 `clever-agent-project`의 preflight를 먼저 통과한다.
+
+```bash
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+```
+
+preflight는 `gh auth status`, GitHub login `OziinG`, `EVNSolution` org membership, 3레포 로컬 workspace, `EVNSolution/*` origin, clean worktree, remote fetch, issue/PR/ruleset read access를 확인한다.
+
+GitHub admin 권한이 필요한 target repo ruleset/protection 작업 전에는 대상 repo를 지정해 admin preflight를 다시 통과한다.
+
+```bash
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py \
+  --cwd "$PWD" \
+  --admin-preflight \
+  --target-repo-full-name EVNSolution/<target-repo> \
+  --json
+```
+
+새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 membership과 API 접근을 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
+
 ### root intake
 
 새 작업 라인을 여는 intake 단계에서는 아래를 먼저 맞춘다.

--- a/docs/root/deploy-template-governance.md
+++ b/docs/root/deploy-template-governance.md
@@ -16,13 +16,13 @@
 ## SSOT 경계
 
 - 현재 중앙 배포 런타임 truth는 `docs/root/central-deploy-runtime-current-truth.md`를 우선 기준으로 본다.
-- current deploy baseline을 template lineage로 읽을 때는 `docs/templates/Clever-ODIC-deploy/` family를 먼저 본다.
+- current deploy baseline을 template lineage로 읽을 때는 `docs/templates/Clever-OIDC-deploy/` family를 먼저 본다.
 - 서비스 문서는 공통 배포 절차를 다시 쓰지 않고, 서비스 고유 차이만 적는다.
 - `templates/deploy/`는 root 규칙을 재사용하기 위한 boilerplate와 예시 자산을 둔다.
 
 ## 공통 deploy baseline
 
-현재 공통 deploy baseline은 `Clever-ODIC-deploy` family로 읽는다.
+현재 공통 deploy baseline은 `Clever-OIDC-deploy` family로 읽는다.
 
 이 baseline은 monorepo와 MSA를 서로 다른 deploy 방식으로 설명하지 않는다.
 
@@ -153,8 +153,8 @@ customer-specific override는 아래처럼 나눠 적는다.
 
 ## 관련 문서
 
-- `docs/templates/Clever-ODIC-deploy/index.md`
-- `docs/templates/Clever-ODIC-deploy/versions/v1.md`
+- `docs/templates/Clever-OIDC-deploy/index.md`
+- `docs/templates/Clever-OIDC-deploy/versions/v1.md`
 - `docs/root/central-deploy-runtime-current-truth.md`
 - `docs/root/msa-saas-replication-governance.md`
 - `docs/services/service-template.md`

--- a/docs/superpowers/plans/2026-04-22-clever-oidc-deploy-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-22-clever-oidc-deploy-implementation-plan.md
@@ -1,21 +1,21 @@
-# Clever-ODIC-deploy Implementation Plan
+# Clever-OIDC-deploy Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** `Clever-ODIC-deploy`를 `clever-context-monorepo`의 정식 deploy template family로 추가하고, root deploy governance와 reusable deploy assets를 최신 배포 정본에 맞게 정렬한다.
+**Goal:** `Clever-OIDC-deploy`를 `clever-context-monorepo`의 정식 deploy template family로 추가하고, root deploy governance와 reusable deploy assets를 최신 배포 정본에 맞게 정렬한다.
 
-**Architecture:** 새 template family 문서를 `docs/templates/Clever-ODIC-deploy/` 아래에 추가하고, registry와 root governance에서 이 family를 current deploy baseline으로 읽게 만든다. `templates/deploy/*` 자산은 같은 canonical model을 재사용하도록 재서술하고, monorepo와 MSA는 deploy model이 아니라 workload cardinality 차이로만 설명한다.
+**Architecture:** 새 template family 문서를 `docs/templates/Clever-OIDC-deploy/` 아래에 추가하고, registry와 root governance에서 이 family를 current deploy baseline으로 읽게 만든다. `templates/deploy/*` 자산은 같은 canonical model을 재사용하도록 재서술하고, monorepo와 MSA는 deploy model이 아니라 workload cardinality 차이로만 설명한다.
 
 **Tech Stack:** Markdown docs, template registry docs, reusable deploy template assets, grep/sed/git 기반 문서 검증
 
 ---
 
-### Task 1: Add the Clever-ODIC-deploy template family documents
+### Task 1: Add the Clever-OIDC-deploy template family documents
 
 **Files:**
-- Create: `docs/templates/Clever-ODIC-deploy/index.md`
-- Create: `docs/templates/Clever-ODIC-deploy/versions/v1.md`
-- Reference: `docs/superpowers/specs/2026-04-22-clever-odic-deploy-design.md`
+- Create: `docs/templates/Clever-OIDC-deploy/index.md`
+- Create: `docs/templates/Clever-OIDC-deploy/versions/v1.md`
+- Reference: `docs/superpowers/specs/2026-04-22-clever-oidc-deploy-design.md`
 - Reference: `docs/templates/msa-template/index.md`
 - Reference: `docs/templates/msa-template/versions/v1.md`
 
@@ -23,7 +23,7 @@
 
 Run:
 ```bash
-sed -n '1,260p' docs/superpowers/specs/2026-04-22-clever-odic-deploy-design.md
+sed -n '1,260p' docs/superpowers/specs/2026-04-22-clever-oidc-deploy-design.md
 sed -n '1,220p' docs/templates/msa-template/index.md
 sed -n '1,260p' docs/templates/msa-template/versions/v1.md
 ```
@@ -34,9 +34,9 @@ Expected:
 
 - [ ] **Step 2: Create the family entry document**
 
-Create `docs/templates/Clever-ODIC-deploy/index.md` with:
+Create `docs/templates/Clever-OIDC-deploy/index.md` with:
 ```md
-# Clever-ODIC-deploy
+# Clever-OIDC-deploy
 
 ## 목적
 
@@ -57,13 +57,13 @@ Create `docs/templates/Clever-ODIC-deploy/index.md` with:
 
 - [ ] **Step 3: Create the concrete v1 document**
 
-Create `docs/templates/Clever-ODIC-deploy/versions/v1.md` with:
+Create `docs/templates/Clever-OIDC-deploy/versions/v1.md` with:
 ```md
-# Clever-ODIC-deploy v1
+# Clever-OIDC-deploy v1
 
 ## version meta
 
-- `template_id`: `Clever-ODIC-deploy`
+- `template_id`: `Clever-OIDC-deploy`
 - `version`: `v1`
 - `status`: `recommended`
 - `project_type`: `monorepo single-workload / msa multi-workload`
@@ -82,9 +82,9 @@ Include:
 
 Run:
 ```bash
-rg -n "Clever-ODIC-deploy|image-build-once-central-release|single workload|multiple workload|public contract probe" \
-  docs/templates/Clever-ODIC-deploy/index.md \
-  docs/templates/Clever-ODIC-deploy/versions/v1.md
+rg -n "Clever-OIDC-deploy|image-build-once-central-release|single workload|multiple workload|public contract probe" \
+  docs/templates/Clever-OIDC-deploy/index.md \
+  docs/templates/Clever-OIDC-deploy/versions/v1.md
 ```
 
 Expected:
@@ -94,8 +94,8 @@ Expected:
 
 Run:
 ```bash
-git add docs/templates/Clever-ODIC-deploy/index.md docs/templates/Clever-ODIC-deploy/versions/v1.md
-git commit -m "Add Clever-ODIC-deploy template family"
+git add docs/templates/Clever-OIDC-deploy/index.md docs/templates/Clever-OIDC-deploy/versions/v1.md
+git commit -m "Add Clever-OIDC-deploy template family"
 ```
 
 ### Task 2: Register the template and align root governance
@@ -119,11 +119,11 @@ Expected:
 - registry entry fields와 root governance phrasing을 확인한다.
 - current runtime truth wording을 그대로 재사용할 부분을 고른다.
 
-- [ ] **Step 2: Add Clever-ODIC-deploy to the template registry**
+- [ ] **Step 2: Add Clever-OIDC-deploy to the template registry**
 
 Update `docs/templates/index.md` to add a new entry with:
 ```md
-### `Clever-ODIC-deploy`
+### `Clever-OIDC-deploy`
 
 - status: `recommended`
 - latest version: `v1`
@@ -139,7 +139,7 @@ Also note:
 - [ ] **Step 3: Align deploy-template-governance to the new baseline**
 
 Update `docs/root/deploy-template-governance.md` so it explicitly states:
-- current deploy baseline is read through `Clever-ODIC-deploy`
+- current deploy baseline is read through `Clever-OIDC-deploy`
 - app repo build / central release / runtime inventory split is the reusable model
 - monorepo and MSA differ only by workload cardinality
 
@@ -147,7 +147,7 @@ Update `docs/root/deploy-template-governance.md` so it explicitly states:
 
 Run:
 ```bash
-rg -n "Clever-ODIC-deploy|image-build-once-central-release|workload cardinality|current deploy baseline|runtime inventory" \
+rg -n "Clever-OIDC-deploy|image-build-once-central-release|workload cardinality|current deploy baseline|runtime inventory" \
   docs/templates/index.md \
   docs/root/deploy-template-governance.md
 ```
@@ -161,7 +161,7 @@ Expected:
 Run:
 ```bash
 git add docs/templates/index.md docs/root/deploy-template-governance.md
-git commit -m "Register Clever-ODIC-deploy baseline"
+git commit -m "Register Clever-OIDC-deploy baseline"
 ```
 
 ### Task 3: Rework reusable deploy assets to match the canonical model
@@ -171,7 +171,7 @@ git commit -m "Register Clever-ODIC-deploy baseline"
 - Modify: `templates/deploy/checklist.md`
 - Modify: `templates/deploy/env-template.example`
 - Modify: `templates/deploy/override-guide.md`
-- Reference: `docs/templates/Clever-ODIC-deploy/versions/v1.md`
+- Reference: `docs/templates/Clever-OIDC-deploy/versions/v1.md`
 
 - [ ] **Step 1: Read the current deploy assets**
 
@@ -232,14 +232,14 @@ Expected:
 Run:
 ```bash
 git add templates/deploy/README.md templates/deploy/checklist.md templates/deploy/env-template.example templates/deploy/override-guide.md
-git commit -m "Align deploy assets with Clever-ODIC-deploy"
+git commit -m "Align deploy assets with Clever-OIDC-deploy"
 ```
 
 ### Task 4: Run final document consistency checks
 
 **Files:**
-- Verify: `docs/templates/Clever-ODIC-deploy/index.md`
-- Verify: `docs/templates/Clever-ODIC-deploy/versions/v1.md`
+- Verify: `docs/templates/Clever-OIDC-deploy/index.md`
+- Verify: `docs/templates/Clever-OIDC-deploy/versions/v1.md`
 - Verify: `docs/templates/index.md`
 - Verify: `docs/root/deploy-template-governance.md`
 - Verify: `templates/deploy/README.md`
@@ -251,8 +251,8 @@ git commit -m "Align deploy assets with Clever-ODIC-deploy"
 
 Run:
 ```bash
-rg -n "Clever-ODIC-deploy|image-build-once-central-release|single workload|multiple workloads|public contract probe|runtime inventory" \
-  docs/templates/Clever-ODIC-deploy \
+rg -n "Clever-OIDC-deploy|image-build-once-central-release|single workload|multiple workloads|public contract probe|runtime inventory" \
+  docs/templates/Clever-OIDC-deploy \
   docs/templates/index.md \
   docs/root/deploy-template-governance.md \
   templates/deploy
@@ -265,7 +265,7 @@ Expected:
 
 Run:
 ```bash
-git diff -- docs/templates/Clever-ODIC-deploy docs/templates/index.md docs/root/deploy-template-governance.md templates/deploy
+git diff -- docs/templates/Clever-OIDC-deploy docs/templates/index.md docs/root/deploy-template-governance.md templates/deploy
 ```
 
 Expected:
@@ -285,8 +285,8 @@ Expected:
 
 Run:
 ```bash
-git add docs/templates/Clever-ODIC-deploy docs/templates/index.md docs/root/deploy-template-governance.md templates/deploy
-git commit -m "Document Clever-ODIC-deploy baseline"
+git add docs/templates/Clever-OIDC-deploy docs/templates/index.md docs/root/deploy-template-governance.md templates/deploy
+git commit -m "Document Clever-OIDC-deploy baseline"
 ```
 
 - [ ] **Step 5: Push after review**
@@ -297,4 +297,4 @@ git push origin main
 ```
 
 Expected:
-- `main`에 `Clever-ODIC-deploy` template baseline 문서가 반영된다.
+- `main`에 `Clever-OIDC-deploy` template baseline 문서가 반영된다.

--- a/docs/superpowers/specs/2026-04-22-clever-oidc-deploy-design.md
+++ b/docs/superpowers/specs/2026-04-22-clever-oidc-deploy-design.md
@@ -1,8 +1,8 @@
-# Clever-ODIC-deploy Design
+# Clever-OIDC-deploy Design
 
 ## 목적
 
-이 문서는 `Clever-ODIC-deploy`를 `clever-context-monorepo` 안의 정식 deploy template family로 추가하는 설계를 고정한다.
+이 문서는 `Clever-OIDC-deploy`를 `clever-context-monorepo` 안의 정식 deploy template family로 추가하는 설계를 고정한다.
 
 이 설계는 새 배포 저장소를 만드는 것이 아니라, 현재 최신 배포 정본을 template registry, root governance, reusable asset 구조로 승격하는 것을 목표로 한다.
 
@@ -17,7 +17,7 @@
 
 ## 설계 목표
 
-- `Clever-ODIC-deploy`를 정식 template family로 registry에 등록한다.
+- `Clever-OIDC-deploy`를 정식 template family로 registry에 등록한다.
 - 최신 배포 정본을 아래 모델로 고정한다.
   - app repo는 image build만 담당
   - central release lane이 실제 deploy를 담당
@@ -36,7 +36,7 @@
 
 ## 채택 모델
 
-`Clever-ODIC-deploy`의 canonical deploy model은 아래 한 줄이다.
+`Clever-OIDC-deploy`의 canonical deploy model은 아래 한 줄이다.
 
 `repo main build -> immutable image artifact -> central release resolve -> runtime inventory scoped deploy -> public contract probe -> release evidence`
 
@@ -99,8 +99,8 @@ monorepo와 MSA의 차이는 artifact cardinality와 workload cardinality에만 
 
 ### 새로 추가
 
-- `docs/templates/Clever-ODIC-deploy/index.md`
-- `docs/templates/Clever-ODIC-deploy/versions/v1.md`
+- `docs/templates/Clever-OIDC-deploy/index.md`
+- `docs/templates/Clever-OIDC-deploy/versions/v1.md`
 
 ### 갱신
 
@@ -113,7 +113,7 @@ monorepo와 MSA의 차이는 artifact cardinality와 workload cardinality에만 
 
 ## 문서별 책임
 
-### `docs/templates/Clever-ODIC-deploy/index.md`
+### `docs/templates/Clever-OIDC-deploy/index.md`
 
 template family entry 역할을 가진다.
 
@@ -126,7 +126,7 @@ template family entry 역할을 가진다.
 - current authority 링크
 - version 문서 링크
 
-### `docs/templates/Clever-ODIC-deploy/versions/v1.md`
+### `docs/templates/Clever-OIDC-deploy/versions/v1.md`
 
 `v1`의 concrete baseline을 설명한다.
 
@@ -143,7 +143,7 @@ template family entry 역할을 가진다.
 
 ### `docs/templates/index.md`
 
-registry entry로 `Clever-ODIC-deploy`를 추가한다.
+registry entry로 `Clever-OIDC-deploy`를 추가한다.
 
 registry 표시는 아래처럼 읽히게 한다.
 
@@ -154,7 +154,7 @@ registry 표시는 아래처럼 읽히게 한다.
 
 기존 템플릿과의 관계도 짧게 적는다.
 
-- `Clever-ODIC-deploy`: 현재 deploy 정본
+- `Clever-OIDC-deploy`: 현재 deploy 정본
 - `msa-template`: family-level 설명용 entry
 - `test-erik-project-template`: 특정 monorepo scaffold와 infra posture를 가진 별도 템플릿
 
@@ -162,7 +162,7 @@ registry 표시는 아래처럼 읽히게 한다.
 
 root 기준 문서로서 아래를 분명히 한다.
 
-- current deploy baseline은 `Clever-ODIC-deploy` family로 읽는다
+- current deploy baseline은 `Clever-OIDC-deploy` family로 읽는다
 - reusable asset은 `templates/deploy/`에 두되 current truth 자체를 대체하지는 않는다
 - monorepo와 MSA는 같은 deploy model의 다른 workload cardinality일 뿐이다
 
@@ -237,7 +237,7 @@ monorepo는 single workload 예시, MSA는 workload별 변수 naming 예시를 �
 
 ## 오류 모델
 
-`Clever-ODIC-deploy`는 모든 배포 오류를 막지 않는다.
+`Clever-OIDC-deploy`는 모든 배포 오류를 막지 않는다.
 
 대신 아래 class 오류를 줄이는 데 책임이 있다.
 
@@ -257,12 +257,12 @@ monorepo는 single workload 예시, MSA는 workload별 변수 naming 예시를 �
 
 ## 마이그레이션 해석
 
-기존 서비스가 아래 조건이면 `Clever-ODIC-deploy` 채택 또는 migration 검토 대상으로 본다.
+기존 서비스가 아래 조건이면 `Clever-OIDC-deploy` 채택 또는 migration 검토 대상으로 본다.
 
 - 현재 image artifact + central release + runtime inventory 모델을 실제로 따르고 있다
 - 하지만 서비스 문서에 그 lineage가 명시돼 있지 않다
 
-이 경우 신규 서비스는 `Clever-ODIC-deploy@v1`을 기본 추천으로 두고, 기존 서비스는 service metadata에 lineage를 보강한다.
+이 경우 신규 서비스는 `Clever-OIDC-deploy@v1`을 기본 추천으로 두고, 기존 서비스는 service metadata에 lineage를 보강한다.
 
 ## 테스트와 검증
 
@@ -275,7 +275,7 @@ monorepo는 single workload 예시, MSA는 workload별 변수 naming 예시를 �
 
 ## 구현 순서
 
-1. `Clever-ODIC-deploy` spec 승인
+1. `Clever-OIDC-deploy` spec 승인
 2. template family 문서 추가
 3. registry 갱신
 4. root deploy governance 갱신

--- a/docs/templates/Clever-OIDC-deploy/index.md
+++ b/docs/templates/Clever-OIDC-deploy/index.md
@@ -1,8 +1,8 @@
-# Clever-ODIC-deploy
+# Clever-OIDC-deploy
 
 ## 목적
 
-이 문서는 `Clever-ODIC-deploy` family entry다.
+이 문서는 `Clever-OIDC-deploy` family entry다.
 
 이 family는 CLEVER의 현재 deploy 정본을 template registry에서 재사용 가능한 형태로 올린 entry다.
 
@@ -15,7 +15,7 @@
 
 ## registry 요약
 
-- `template_id`: `Clever-ODIC-deploy`
+- `template_id`: `Clever-OIDC-deploy`
 - `current_version`: `v1`
 - `status`: `recommended`
 - `use_case`: current CLEVER deploy baseline for monorepo and MSA
@@ -75,7 +75,7 @@
 
 1. `docs/root/deploy-template-governance.md`
 2. `docs/root/central-deploy-runtime-current-truth.md`
-3. `docs/templates/Clever-ODIC-deploy/versions/v1.md`
+3. `docs/templates/Clever-OIDC-deploy/versions/v1.md`
 4. `templates/deploy/README.md`
 5. 해당 서비스 문서
 

--- a/docs/templates/Clever-OIDC-deploy/versions/v1.md
+++ b/docs/templates/Clever-OIDC-deploy/versions/v1.md
@@ -1,8 +1,8 @@
-# Clever-ODIC-deploy v1
+# Clever-OIDC-deploy v1
 
 ## version meta
 
-- `template_id`: `Clever-ODIC-deploy`
+- `template_id`: `Clever-OIDC-deploy`
 - `version`: `v1`
 - `status`: `recommended`
 - `project_type`: `monorepo single-workload / msa multi-workload`

--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -24,7 +24,7 @@
 
 ## 등록된 템플릿
 
-### `Clever-ODIC-deploy`
+### `Clever-OIDC-deploy`
 
 - status: `recommended`
 - latest version: `v1`
@@ -33,8 +33,8 @@
 - summary: current CLEVER deploy truth elevated as a reusable template family
 - note: current deploy baseline을 template lineage로 기록하기 위한 family entry다. monorepo는 single workload, MSA는 multiple workloads로 읽되, 둘 다 같은 release/inventory/contract probe 모델을 따른다.
 - 문서:
-  - [`docs/templates/Clever-ODIC-deploy/index.md`](./Clever-ODIC-deploy/index.md)
-  - [`docs/templates/Clever-ODIC-deploy/versions/v1.md`](./Clever-ODIC-deploy/versions/v1.md)
+  - [`docs/templates/Clever-OIDC-deploy/index.md`](./Clever-OIDC-deploy/index.md)
+  - [`docs/templates/Clever-OIDC-deploy/versions/v1.md`](./Clever-OIDC-deploy/versions/v1.md)
 
 ### `msa-template`
 
@@ -43,7 +43,7 @@
 - use_case: package-style MSA template family registry
 - deploy_profile: `image-build-once-and-promote`
 - summary: 운영, 인프라, 프론트, 게이트웨이, 서비스 archetype을 묶어 설명하는 generic MSA template family 문서
-- note: family 구조와 archetype 조합을 설명하는 entry다. current deploy baseline 자체를 설명하는 역할은 `Clever-ODIC-deploy` family가 우선 가진다.
+- note: family 구조와 archetype 조합을 설명하는 entry다. current deploy baseline 자체를 설명하는 역할은 `Clever-OIDC-deploy` family가 우선 가진다.
 - 문서:
   - [`docs/templates/msa-template/index.md`](./msa-template/index.md)
   - [`docs/templates/msa-template/versions/v1.md`](./msa-template/versions/v1.md)

--- a/templates/deploy/README.md
+++ b/templates/deploy/README.md
@@ -4,13 +4,13 @@
 
 이 디렉터리는 공통 deploy baseline을 반복 가능하게 쓰기 위한 자산 모음이다.
 
-이 자산은 `Clever-ODIC-deploy` family가 설명하는 current deploy baseline을 반복 가능하게 쓰기 위한 boilerplate다.
+이 자산은 `Clever-OIDC-deploy` family가 설명하는 current deploy baseline을 반복 가능하게 쓰기 위한 boilerplate다.
 
 정본 규칙은 아래 순서로 읽는다.
 
 1. `docs/root/deploy-template-governance.md`
 2. `docs/root/central-deploy-runtime-current-truth.md`
-3. `docs/templates/Clever-ODIC-deploy/versions/v1.md`
+3. `docs/templates/Clever-OIDC-deploy/versions/v1.md`
 
 ## 포함 자산
 


### PR DESCRIPTION
## Summary
- Rename Clever-ODIC-deploy docs, registry references, and reusable deploy asset links to Clever-OIDC-deploy.
- Preserve the existing deploy baseline semantics while fixing the OIDC spelling.

## Review
- Reviewed the final diff against origin/main; no blocking issues found.

## Verification
- git diff --check origin/main..HEAD
- rg -n "ODIC|odic" . --glob '!_sandbox/**' returns no matches