### PR TITLE
docs: add PR branch cleanup contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,32 @@ Merge body should start with the PR title, then include the merge summary,
 validation evidence, and wiki/service context update result. Do not use a plain
 feature/doc commit title as the main merge commit subject.
 
+## PR Branch Cleanup Contract
+
+PR 완료 후 branch 정리:
+
+After a PR is merged, or closed with the source branch intentionally abandoned,
+clean up the task branch unless it still has an open PR, linked follow-up issue,
+child branch, or active release/hotfix use.
+
+Default command sequence:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git branch -d <source-branch>
+git push origin --delete <source-branch>
+git fetch --prune origin
+```
+
+- `main`과 `dev`는 삭제 대상이 아니다.
+- Use `git branch -d <source-branch>` by default.
+- Use `git branch -D <source-branch>` only when the PR was closed without merge
+  and the user explicitly confirms the branch can be discarded.
+- Do not delete a remote branch if it still backs an open PR, follow-up issue,
+  child branch, or active release/hotfix.
+- If GitHub already deleted the remote branch, still run `git fetch --prune origin`.
+
 Do not treat this repository as:
 
 - the default generic startup surface

--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ admin bypass는 `pull_request` 모드만 허용한다.
 Merge pull request #<pr-number> from <owner>/<source-branch>
 ```
 
+### PR 완료 후 branch 정리
+
+PR이 merge됐거나 source branch를 버리기로 하고 closed 처리된 뒤에는 task
+branch를 정리한다. 단, 해당 branch가 아직 open PR, 후속 issue, child branch,
+active release/hotfix에 쓰이면 삭제하지 않는다.
+
+기본 명령은 아래 순서다.
+
+```bash
+git switch main
+git pull --ff-only origin main
+git branch -d <source-branch>
+git push origin --delete <source-branch>
+git fetch --prune origin
+```
+
+- `main`과 `dev`는 삭제 대상이 아니다.
+- 기본은 `git branch -d <source-branch>`를 쓴다.
+- merge 없이 닫은 branch를 폐기해야 할 때만 사용자 확인 후 `git branch -D <source-branch>`를 쓴다.
+- remote branch가 GitHub에서 이미 삭제됐더라도 `git fetch --prune origin`으로 로컬 추적 branch를 정리한다.
+
 ## clever-change-control과의 관계
 
 `clever-change-control`은 변경 요청, 승인, rollout/rollback 흐름을 관리한다. 이 저장소는 그 흐름에서 참조하는 정본 문맥, 규칙, 용어, 계약을 관리한다.


### PR DESCRIPTION
## 변경 내용
- `AGENTS.md`와 `README.md`에 PR 완료 후 branch 정리 계약 추가
- remote branch 삭제 명령 `git push origin --delete <source-branch>`와 `git fetch --prune origin` 명시
- open PR, 후속 issue, child branch, active release/hotfix가 있으면 삭제하지 않는 조건 명시

## 검증
- `python3 clever-agent-project/scripts/bootstrap_clever_work.py --cwd clever-agent-project --preflight --json` -> ready true
- `git fetch origin main --prune` 후 `HEAD...origin/main` -> `0 0`
- `git diff --check`
- PR 생성 전 open PR 없음 확인

## Concurrent Work Gate
- parallel work decision: `allowed-with-non-overlap`
- target repo issue: none
- clever-change-control issue: none
- open PR checked: no open PR used as blocker
- conflict candidates: none
- user-forced-proceed reason: not used

## CLEVER PR review completion
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `updated`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: this PR
- not-needed reason: AGENTS/README operational contract only
