### PR TITLE
docs: add PR scope grouping gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,18 @@
 
 -
 
+## PR Scope Grouping Gate
+
+- grouping decision: `single-pr` / `split-required`
+- same document/operating-rule cleanup:
+- same validation command:
+- different app/service/contract surface:
+- merge order dependency:
+- rollback unit:
+
+같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
+앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.
+
 ## 테스트 여부
 
 -

--- a/docs/root/pipeline-governance.md
+++ b/docs/root/pipeline-governance.md
@@ -44,6 +44,25 @@ gh pr merge <pr-number> --squash \
 merge body 첫 줄에는 PR title을 남기고, 이어서 merge summary, validation evidence, wiki/service context update result를 남긴다.
 일반 작업 commit 제목을 그대로 main merge commit 제목으로 쓰지 않는다.
 
+## PR Scope Grouping Gate
+
+PR은 파일 수가 아니라 변경 축, 검증 단위, 롤백 단위로 나눈다.
+
+같은 issue 안에서 same document/operating-rule cleanup 축이고 same validation command로
+충분하면 한 PR로 묶는다. `AGENTS.md`, PR template, startup state
+template, project brief template, design source policy, merge title template
+sync처럼 같은 운영 규칙을 맞추는 작은 문서 정리는 한 PR로 처리한다.
+
+분리 PR은 아래 경우에 쓴다.
+
+- different app/service/contract surface를 건드린다.
+- 테스트 범위와 실패 지점이 다르다.
+- merge order dependency가 있다.
+- 실패 시 rollback unit이 다르다.
+
+OpenAPI schema 변경, Admin Web smoke 화면, Rider App smoke 화면, Spring
+service mock endpoint 구현은 보통 분리 PR로 다룬다.
+
 ## 제외
 
 - 서버 배포 절차 상세


### PR DESCRIPTION
## change id

- not assigned

## 관련 issue

- not assigned

## 대상 repo/service

- `EVNSolution/clever-context-monorepo`
- service: root pipeline governance

## 변경 내용

- Add `PR Scope Grouping Gate` to root pipeline governance.
- Add the same grouping decision fields to the repo PR template.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: yes, PR grouping policy and templates are one operating-rule sync.
- same validation command: yes, workspace doc/template sync is covered by the same pytest and diff-check verification.
- different app/service/contract surface: no product app, service, API, or contract surface changes.
- merge order dependency: none.
- rollback unit: repo-local docs/templates only.

## 테스트 여부

- `python3 -m pytest -q` in `clever-agent-project`: 55 passed, 2 skipped
- `git diff --check` in `clever-agent-project`: passed
- `git diff --check` in `clever-context-monorepo`: passed
- `git diff --check` in `clever-change-control`: passed

## 검수 포인트

- Root pipeline governance now records when docs/operating-rule cleanup should stay in one PR.
- PR template now asks for the grouping decision and split criteria.

## rollout/rollback 영향

- No runtime rollout impact.
- Rollback is reverting this docs/templates commit.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: not assigned
- clever-change-control issue: not assigned
- open PR checked: none open at creation time
- conflict candidates: none
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `docs/root/pipeline-governance.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `updated`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: this PR
- linked issue close evidence: not assigned
