### PR TITLE
docs: add retro trace repair rule to context handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,13 @@ Use `fixes`, `closes`, or similar GitHub keywords only when the PR merge is
 intended to close the referenced issue. Use plain issue mentions for context
 links.
 
+Retroactive trace repair follows the same control-plane rule: if completed
+target work is missing a scoped change-control anchor, open a retro issue in
+`clever-change-control`, record root/target/branch/PR with
+`parallel work decision: done`, backlink the target issue, then close the retro
+issue as completed. This records audit evidence only and does not reopen the
+completed implementation scope.
+
 ## Read Order For Repo-Local Work
 
 When the task is specifically about this repository, read in this order:


### PR DESCRIPTION
## Summary
- Add the retroactive trace repair handoff rule to the context repo AGENTS instructions.
- Keep context-originated target work aligned with the control-plane open/backlink/close audit trail.

## Trace
- Change-control: EVNSolution/clever-change-control#30
- Target issue: EVNSolution/clever-context-monorepo#15

## Validation
- `git diff --check`

## Scope
- Documentation only.
- No ThunderCrew target repo changes included.
