### PR TITLE
[codex] Clarify MSA boundary governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ MSA 전체는 product service로 보고, `service-*`, `front-*`, `edge-*`, `runt
 
 MSA는 runtime slice를 하나 더 붙이는 구조가 아니라, 책임·데이터 소유권·API
 edge 계약을 먼저 나눈 뒤 workload와 연결하는 구조다. 전역 판단 기준은
-`docs/root/msa-boundary-governance.md`를 따른다.
+[`docs/root/msa-boundary-governance.md`](./docs/root/msa-boundary-governance.md)를 따른다.
 
 runtime slice별 API, env, ECR, commit, rollout caveat는 이 repo에 복제하지 않는다. 해당 정보는 소유 repo의 정본 문서를 직접 본다.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ agent는 하나의 실행자다. global과 local은 agent 종류가 아니라 �
 
 MSA 전체는 product service로 보고, `service-*`, `front-*`, `edge-*`, `runtime-*`는 runtime slice로 부른다.
 
+MSA는 runtime slice를 하나 더 붙이는 구조가 아니라, 책임·데이터 소유권·API
+edge 계약을 먼저 나눈 뒤 workload와 연결하는 구조다. 전역 판단 기준은
+`docs/root/msa-boundary-governance.md`를 따른다.
+
 runtime slice별 API, env, ECR, commit, rollout caveat는 이 repo에 복제하지 않는다. 해당 정보는 소유 repo의 정본 문서를 직접 본다.
 
 ## main 브랜치 운영 규칙

--- a/docs/root/architecture-principles.md
+++ b/docs/root/architecture-principles.md
@@ -19,5 +19,7 @@
 
 runtime slice를 새로 만들거나 나눌 때는
 [`msa-boundary-governance.md`](./msa-boundary-governance.md)를 먼저 본다.
-새 slice는 독립 책임, 데이터/table ownership, API edge 또는 release/workload
-경계가 있을 때만 정당화된다.
+새 slice는 독립 책임과 authority statement가 먼저 있어야 하며, 데이터/table
+ownership, API edge authority, release/workload 경계 중 무엇이 기존 slice
+확장만으로 부족한지 설명될 때만 정당화된다. API edge 추가만으로는 새 slice가
+아니라 contract/API edge 변경으로 먼저 본다.

--- a/docs/root/architecture-principles.md
+++ b/docs/root/architecture-principles.md
@@ -3,6 +3,7 @@
 ## 기본 원칙
 
 - product service와 runtime slice 경계는 명확하게 유지한다.
+- MSA는 새 service를 붙이는 방식이 아니라 책임, 데이터 소유권, API edge를 분리하는 방식이다.
 - 공통 규칙은 `contracts` 또는 `docs/root`에 둔다.
 - runtime slice 내부 결정은 소유 repo 문서에 둔다.
 - root 작업 라인은 `project-start issue #`로 연결한다.
@@ -13,3 +14,10 @@
 - 전역 구조 판단은 root 문서를 따른다.
 - runtime slice 구현 판단은 소유 repo 문서를 따른다.
 - 충돌 시 상위 우선순위 문서를 기준으로 정리한다.
+
+## MSA 경계 판단
+
+runtime slice를 새로 만들거나 나눌 때는
+[`msa-boundary-governance.md`](./msa-boundary-governance.md)를 먼저 본다.
+새 slice는 독립 책임, 데이터/table ownership, API edge 또는 release/workload
+경계가 있을 때만 정당화된다.

--- a/docs/root/clever-msa-platform-workspace.md
+++ b/docs/root/clever-msa-platform-workspace.md
@@ -7,6 +7,10 @@
 CLEVER MSA platform은 product service 단위에서 하나로 본다. 그 안의
 `service-*`, `front-*`, `edge-*`, `runtime-*`는 runtime slice다.
 
+MSA 경계 판단은 [`msa-boundary-governance.md`](./msa-boundary-governance.md)를
+따른다. 실제 slice별 책임, 테이블, API, release inventory는 아래 Current
+Authority 문서가 소유한다.
+
 ## Current Authority
 
 CLEVER MSA platform의 구조, runtime slice, deploy, boundary, contract 사실은

--- a/docs/root/domain-glossary.md
+++ b/docs/root/domain-glossary.md
@@ -11,7 +11,7 @@
 - target slice: 변경이 반영되는 runtime slice
 - API edge: runtime slice 사이의 호출, routing, public contract 노출, authentication handoff가 만나는 연결부. 데이터 소유권은 API edge가 아니라 owning slice가 가진다.
 - owned data boundary: write authority를 가진 slice와 그 slice가 소유하는 table/read source 경계
-- authority statement: 새 service/slice 후보가 데이터, API contract, 외부 provider, 운영 권한 중 무엇을 소유하는지 설명하는 문장
+- authority statement: 새 runtime slice 또는 별도 service 후보가 데이터, API contract, 외부 provider, 운영 권한 중 무엇을 소유하는지 설명하는 문장
 - read model: 원천 데이터를 직접 소유하지 않고 조회 목적에 맞게 투영한 모델. 원천 owning slice와 consumer slice를 구분해서 기록한다.
 - spec: 기능과 동작 기준 문서
 - ui-spec: 화면, 상태, 상호작용 기준 문서
@@ -28,5 +28,5 @@
 - `service-*` 디렉터리를 product service라고 부르지 않는다.
 - target이 애매하면 `target slice`를 먼저 쓰고, 사용자가 보는 상위 단위는 `product service`로 분리한다.
 - 새 MSA slice 여부가 애매하면 책임, owned data boundary, API edge, workload boundary를 먼저 확인한다.
-- 에이전트가 새 service/slice를 제안하면 authority statement와 대안 검토를 같이 남긴다.
+- 에이전트가 새 runtime slice 또는 별도 service 후보를 제안하면 authority statement와 대안 검토를 같이 남긴다.
 - 새로운 용어를 추가할 때는 먼저 이 문서를 갱신한다.

--- a/docs/root/domain-glossary.md
+++ b/docs/root/domain-glossary.md
@@ -11,6 +11,7 @@
 - target slice: 변경이 반영되는 runtime slice
 - API edge: runtime slice 사이의 호출, routing, public contract 노출, authentication handoff가 만나는 연결부. 데이터 소유권은 API edge가 아니라 owning slice가 가진다.
 - owned data boundary: write authority를 가진 slice와 그 slice가 소유하는 table/read source 경계
+- authority statement: 새 service/slice 후보가 데이터, API contract, 외부 provider, 운영 권한 중 무엇을 소유하는지 설명하는 문장
 - read model: 원천 데이터를 직접 소유하지 않고 조회 목적에 맞게 투영한 모델. 원천 owning slice와 consumer slice를 구분해서 기록한다.
 - spec: 기능과 동작 기준 문서
 - ui-spec: 화면, 상태, 상호작용 기준 문서
@@ -27,4 +28,5 @@
 - `service-*` 디렉터리를 product service라고 부르지 않는다.
 - target이 애매하면 `target slice`를 먼저 쓰고, 사용자가 보는 상위 단위는 `product service`로 분리한다.
 - 새 MSA slice 여부가 애매하면 책임, owned data boundary, API edge, workload boundary를 먼저 확인한다.
+- 에이전트가 새 service/slice를 제안하면 authority statement와 대안 검토를 같이 남긴다.
 - 새로운 용어를 추가할 때는 먼저 이 문서를 갱신한다.

--- a/docs/root/domain-glossary.md
+++ b/docs/root/domain-glossary.md
@@ -9,6 +9,9 @@
 - runtime slice: product service를 구성하는 구현/배포 단위. 예: `service-*`, `front-*`, `edge-*`, `runtime-*`
 - workload: compose, ECS, release inventory에서 다루는 실행 단위
 - target slice: 변경이 반영되는 runtime slice
+- API edge: runtime slice 사이의 호출, routing, public contract 노출, authentication handoff가 만나는 연결부. 데이터 소유권은 API edge가 아니라 owning slice가 가진다.
+- owned data boundary: write authority를 가진 slice와 그 slice가 소유하는 table/read source 경계
+- read model: 원천 데이터를 직접 소유하지 않고 조회 목적에 맞게 투영한 모델. 원천 owning slice와 consumer slice를 구분해서 기록한다.
 - spec: 기능과 동작 기준 문서
 - ui-spec: 화면, 상태, 상호작용 기준 문서
 - contract: 서비스 간 또는 전역 규칙의 약속
@@ -23,4 +26,5 @@
 - 용어는 문서마다 같은 의미로 사용한다.
 - `service-*` 디렉터리를 product service라고 부르지 않는다.
 - target이 애매하면 `target slice`를 먼저 쓰고, 사용자가 보는 상위 단위는 `product service`로 분리한다.
+- 새 MSA slice 여부가 애매하면 책임, owned data boundary, API edge, workload boundary를 먼저 확인한다.
 - 새로운 용어를 추가할 때는 먼저 이 문서를 갱신한다.

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -11,10 +11,11 @@ runtime proof, 서비스별 API/env/ECR/commit 요약, target repo 문서 복사
 1. [`authority-boundaries.md`](./authority-boundaries.md): 3-repo authority 경계
 2. [`doc-governance.md`](./doc-governance.md): 이 repo에 둘 수 있는 문서와 둘 수 없는 문서
 3. [`domain-glossary.md`](./domain-glossary.md): product service, runtime slice, workload 용어
-4. [`agent-runtime-governance.md`](./agent-runtime-governance.md): agent 실행 기준
-5. 필요한 template lineage만 [`docs/templates`](../templates/)에서 확인한다.
-6. CLEVER MSA platform 사실은 [`clever-msa-platform-workspace.md`](./clever-msa-platform-workspace.md)의 pointer를 따라 원 repo에서 확인한다.
-7. 사용자가 명시적으로 요청한 외부 monorepo 작성 pointer는 [`monorepo-write-pointers.md`](./monorepo-write-pointers.md)에서 확인한다.
+4. [`msa-boundary-governance.md`](./msa-boundary-governance.md): MSA 책임·데이터·API edge 경계
+5. [`agent-runtime-governance.md`](./agent-runtime-governance.md): agent 실행 기준
+6. 필요한 template lineage만 [`docs/templates`](../templates/)에서 확인한다.
+7. CLEVER MSA platform 사실은 [`clever-msa-platform-workspace.md`](./clever-msa-platform-workspace.md)의 pointer를 따라 원 repo에서 확인한다.
+8. 사용자가 명시적으로 요청한 외부 monorepo 작성 pointer는 [`monorepo-write-pointers.md`](./monorepo-write-pointers.md)에서 확인한다.
 
 ## 위치 안내
 

--- a/docs/root/msa-boundary-governance.md
+++ b/docs/root/msa-boundary-governance.md
@@ -1,0 +1,97 @@
+# MSA 경계 거버넌스
+
+## 목적
+
+이 문서는 CLEVER에서 MSA를 해석할 때의 전역 경계 규칙을 고정한다.
+
+MSA는 서비스를 하나 더 붙이는 방식이 아니다. 역할과 책임을 먼저 나누고,
+그 책임에 맞는 데이터 소유권과 API edge 계약을 정한 뒤 runtime slice와
+workload를 연결하는 방식이다.
+
+제품별 runtime 사실은 이 repo에 복제하지 않는다. 실제 slice 목록, 테이블,
+API, release inventory는 소유 repo의 정본 문서를 따른다.
+
+## 기준 원칙
+
+- product service는 사용자가 하나로 인식하는 제품/플랫폼 단위다.
+- runtime slice는 product service 안에서 하나의 책임을 소유하는 구현/배포 단위다.
+- workload는 release lane과 runtime inventory가 다루는 실행 단위다.
+- API edge는 slice 사이의 호출·라우팅·계약 연결부다. API edge 자체가 데이터 소유권을 만들지는 않는다.
+
+runtime slice는 아래 질문에 답할 수 있어야 한다.
+
+1. 이 slice가 소유하는 책임은 무엇인가?
+2. 이 slice가 직접 쓰는 데이터나 read model은 무엇인가?
+3. 다른 slice가 이 책임에 접근할 때 어떤 API edge 또는 contract를 거치는가?
+4. deploy 가능한 slice라면 어떤 workload와 health/release boundary로 검증하는가?
+5. 정본 문서는 어느 repo의 어느 문서인가?
+
+위 질문에 답하지 못하면 새 service를 만든 것이 아니라 책임 없는 코드 묶음을
+늘린 것으로 본다.
+
+## 새 runtime slice 판단 규칙
+
+새 기능이 들어올 때는 아래 순서로 판단한다.
+
+1. 기존 slice 내부 변경인가?
+   - 같은 책임, 같은 데이터 소유권, 같은 release boundary 안에서 끝나면 기존 slice 변경으로 둔다.
+2. 기존 slice의 API contract 확장인가?
+   - 책임은 그대로이고 외부 접근 방식만 늘어나면 새 slice가 아니라 contract/API edge 변경으로 둔다.
+3. read model 또는 operations view인가?
+   - 원천 데이터 소유자는 따로 있고 조회 책임만 분리하면 read model slice로 기록한다.
+4. 새 runtime slice인가?
+   - 새로운 책임, 독립된 데이터 소유권 또는 독립 release/workload 경계가 생길 때만 새 slice로 둔다.
+
+편의상 컨트롤러, cron, adapter, 화면을 하나 더 붙이는 것만으로는 새 runtime
+slice가 되지 않는다.
+
+## 데이터와 테이블 경계
+
+- write authority는 한 slice가 소유한다.
+- 다른 slice는 소유 slice의 API, event, read model을 통해 접근한다.
+- 공유 식별자는 contract일 뿐이며, 공유 테이블 소유권을 뜻하지 않는다.
+- read model은 원천 소유자와 소비자 책임을 구분해서 문서화한다.
+- 테이블을 추가하거나 ownership을 옮기는 변경은 app-only 변경이 아니라 boundary 변경으로 본다.
+
+## API edge 경계
+
+- gateway 또는 edge slice는 routing, authentication handoff, public contract 노출을 담당한다.
+- upstream slice의 business responsibility와 데이터 소유권은 upstream slice 문서가 소유한다.
+- gateway 문서는 라우팅과 공개 표면을 소유하고, upstream의 내부 API/env/ECR/runtime 사실을 복제하지 않는다.
+- slice 간 연결을 바꾸면 source slice, consumer slice, API edge, contract owner를 함께 기록한다.
+
+## 문서 위치 규칙
+
+이 repo에는 전역 해석 규칙만 둔다.
+
+허용:
+
+- product service / runtime slice / workload / API edge의 용어와 판단 규칙
+- 새 slice 여부를 판단하는 기준
+- 데이터 소유권과 API edge의 전역 원칙
+- 소유 repo 정본 위치 pointer
+
+금지:
+
+- runtime slice별 API, env, secret, ECR, port, health path
+- 고객사별 테이블/필드/단가/외부 연동값
+- release evidence, smoke proof, host 상태
+- 소유 repo 문서 본문 복제
+
+제품별 사실은 `clever-msa-platform` 같은 소유 repo 문서를 따른다. 이 repo는
+정본 위치가 바뀌었을 때만 pointer를 갱신한다.
+
+## change-control 기록 기준
+
+MSA/SaaS 변경 요청에는 최소 아래 해석 값을 남긴다.
+
+- product service
+- target slice
+- 새 slice 여부
+- workload/release 영향 여부
+- API edge 또는 contract 영향 여부
+- 데이터/table ownership 영향 여부
+
+기존 기록이 `target service`라고만 되어 있으면 실행 단계에서 `target slice`로
+정규화한다. product service와 runtime slice를 같은 `service`라는 단어로
+섞어 쓰지 않는다.

--- a/docs/root/msa-boundary-governance.md
+++ b/docs/root/msa-boundary-governance.md
@@ -45,6 +45,53 @@ runtime slice는 아래 질문에 답할 수 있어야 한다.
 편의상 컨트롤러, cron, adapter, 화면을 하나 더 붙이는 것만으로는 새 runtime
 slice가 되지 않는다.
 
+## 새 service/slice 추가 가능성 지표
+
+에이전트가 "이 기능은 새 service의 책임과 권한이다"라고 판단할 수 있다면,
+새 runtime slice 추가 가능성도 열어둔다. 단, 제안은 감이 아니라 아래 지표로
+설명해야 한다.
+
+새 runtime slice 후보로 볼 수 있는 지표:
+
+- 독립 책임: 기존 slice 책임 문장에 억지로 넣으면 의미가 흐려지는 business capability가 있다.
+- 데이터 권한: 새 write authority, table ownership, 외부 provider 상태 정본, 또는 audit trail 정본이 필요하다.
+- API edge 권한: 둘 이상의 consumer가 안정적인 public/internal contract로 접근해야 한다.
+- 권한·보안 경계: authentication, authorization, PII, credential, compliance 책임이 기존 slice와 다르다.
+- release 경계: 기존 slice와 다른 배포 cadence, rollback 단위, health check, smoke proof가 필요하다.
+- 운영 경계: scaling, failure isolation, SLO, queue/worker lifecycle이 기존 slice와 다르다.
+- 변경 지속성: 임시 glue가 아니라 후속 기능이 같은 책임 아래 계속 쌓일 가능성이 높다.
+- 소유자 경계: 운영자, 도메인 owner, 또는 maintainer가 기존 slice와 다르게 책임질 필요가 있다.
+
+반대로 아래에 가까우면 새 slice가 아니라 기존 slice 변경이나 API contract 확장으로
+먼저 본다.
+
+- 단일 화면, 단일 controller, 단일 cron, 단일 adapter 추가
+- 기존 owning slice의 table을 그대로 CRUD만 하는 얇은 wrapper
+- release, health, rollback 단위가 기존 slice와 완전히 같다
+- consumer가 하나뿐이고 contract가 아직 안정적이지 않다
+- 책임 문장이 "무엇을 소유한다"가 아니라 "어디에 연결한다"로만 설명된다
+- 임시 마이그레이션 또는 일회성 data patch에 가깝다
+
+새 slice 추가는 금지가 아니다. 충분한 지표가 있으면 허용한다. 다만 추가 전에
+기존 slice 확장, read model 분리, API edge 확장, shared contract 보강을
+대안으로 검토하고 왜 부족한지 남긴다.
+
+## 에이전트 제안 기록 기준
+
+에이전트가 새 service/slice 후보를 제안할 때는 아래 값을 짧게 남긴다.
+
+- proposed slice name
+- responsibility statement: 이 slice가 끝까지 책임지는 일
+- authority statement: 데이터, API contract, 외부 provider, 운영 권한 중 무엇을 소유하는지
+- consumers and API edge: 누가 어떤 edge/contract로 접근하는지
+- owned data boundary: 새 table, read model, 외부 상태 정본 여부
+- release boundary: workload, health, rollback 단위가 기존 slice와 다른지
+- alternatives rejected: 기존 slice 확장, read model, API edge 확장으로 충분하지 않은 이유
+- owner docs to update: 소유 repo의 정본 문서 위치
+
+위 값 중 핵심 authority statement와 alternatives rejected가 비어 있으면 새 slice
+제안으로 보지 않는다.
+
 ## 데이터와 테이블 경계
 
 - write authority는 한 slice가 소유한다.

--- a/docs/root/msa-boundary-governance.md
+++ b/docs/root/msa-boundary-governance.md
@@ -45,7 +45,7 @@ runtime slice는 아래 질문에 답할 수 있어야 한다.
 편의상 컨트롤러, cron, adapter, 화면을 하나 더 붙이는 것만으로는 새 runtime
 slice가 되지 않는다.
 
-## 새 service/slice 추가 가능성 지표
+## 새 runtime slice 추가 가능성 지표
 
 에이전트가 "이 기능은 새 service의 책임과 권한이다"라고 판단할 수 있다면,
 새 runtime slice 추가 가능성도 열어둔다. 단, 제안은 감이 아니라 아래 지표로
@@ -78,7 +78,7 @@ slice가 되지 않는다.
 
 ## 에이전트 제안 기록 기준
 
-에이전트가 새 service/slice 후보를 제안할 때는 아래 값을 짧게 남긴다.
+에이전트가 새 runtime slice 또는 별도 service 후보를 제안할 때는 아래 값을 짧게 남긴다.
 
 - proposed slice name
 - responsibility statement: 이 slice가 끝까지 책임지는 일
@@ -89,8 +89,8 @@ slice가 되지 않는다.
 - alternatives rejected: 기존 slice 확장, read model, API edge 확장으로 충분하지 않은 이유
 - owner docs to update: 소유 repo의 정본 문서 위치
 
-위 값 중 핵심 authority statement와 alternatives rejected가 비어 있으면 새 slice
-제안으로 보지 않는다.
+위 값 중 핵심 authority statement 또는 alternatives rejected 중 하나라도 비어
+있으면 새 slice 제안으로 보지 않는다.
 
 ## 데이터와 테이블 경계
 

--- a/docs/root/msa-saas-replication-governance.md
+++ b/docs/root/msa-saas-replication-governance.md
@@ -5,6 +5,7 @@
 이 문서는 MSA/SaaS 복제형 작업의 분기 규칙만 고정한다.
 
 제품과 runtime 사실은 이 repo에 복제하지 않는다.
+MSA 경계 자체의 판단은 [`msa-boundary-governance.md`](./msa-boundary-governance.md)를 따른다.
 
 ## 기준 용어
 
@@ -22,6 +23,7 @@ CLEVER MSA platform은 product service로는 하나다. `service-*`, `front-*`,
 - 같은 product service를 고객사별로 복제 또는 변형한다.
 - runtime slice, workload, image, env, secret, 외부 연동값의 차이를 다룬다.
 - 공통 platform template 위에 customer-specific override를 얹는다.
+- 데이터/table ownership, API edge, release/workload boundary를 고객사별로 분기한다.
 
 아래에 가까우면 일반 개발 작업으로 본다.
 
@@ -34,6 +36,7 @@ CLEVER MSA platform은 product service로는 하나다. `service-*`, `front-*`,
 - customer-specific 사실과 runtime slice별 값은 소유 repo 문서에 둔다.
 - 이 repo에는 service leaf 문서를 만들지 않는다.
 - target이 정해지면 `target service`가 아니라 `target slice`로 기록한다.
+- 새 slice 여부는 책임, 데이터 소유권, API edge, workload 경계가 분리되는지로 판단한다.
 
 ## 하지 말아야 할 것
 
@@ -41,3 +44,4 @@ CLEVER MSA platform은 product service로는 하나다. `service-*`, `front-*`,
 - 고객사별 차이를 이 repo에 요약하지 않는다.
 - runtime proof나 rollout evidence를 이 repo에 올리지 않는다.
 - 소유 repo 문서를 복제해서 context 문서로 만들지 않는다.
+- 단순히 adapter, controller, 화면을 하나 더 붙이는 것을 MSA 분리로 기록하지 않는다.

--- a/docs/templates/msa-template/versions/v1.md
+++ b/docs/templates/msa-template/versions/v1.md
@@ -11,6 +11,8 @@
 ## Scope
 
 이 버전은 MSA archetype family를 문서형 template contract로 고정한다.
+MSA slice 분리는 [`docs/root/msa-boundary-governance.md`](../../../root/msa-boundary-governance.md)의
+책임·데이터 소유권·API edge 기준을 만족해야 한다.
 
 ## Included Archetypes
 
@@ -28,6 +30,7 @@
 - artifact는 immutable tag로 고정한다.
 - verification과 release는 같은 artifact를 재사용한다.
 - env, secret, health path, port, upstream name 같은 deploy contract는 명시적으로 관리한다.
+- service를 붙이는 것만으로 workload가 되지 않으며, 책임과 release boundary가 같이 문서화되어야 한다.
 
 ## Excluded
 


### PR DESCRIPTION
## change id

- not-issued; context governance cleanup linked to `EVNSolution/clever-change-control#24` under parent `#23`

## 관련 issue

- `EVNSolution/clever-change-control#23`
- `EVNSolution/clever-change-control#24`

## 대상 repo/service

- target repo: `EVNSolution/clever-context-monorepo`
- target scope: root interpretation docs for MSA boundary rules
- product service: CLEVER MSA platform, by pointer only
- target slice: not applicable; this PR defines global slice-boundary interpretation rules

## 변경 내용

- Add `docs/root/msa-boundary-governance.md`.
- Define MSA as responsibility, data ownership, API edge, workload/release boundary separation rather than simply attaching another service.
- Add positive indicators for when a new runtime slice or separate service may be justified: independent responsibility, data authority, API edge authority, security boundary, release boundary, operational boundary, sustained change path, and owner boundary.
- Require agent proposals for a new runtime slice or separate service to include responsibility statement, authority statement, consumers/API edge, owned data boundary, release boundary, rejected alternatives, and owner docs to update.
- Clarify that API edge expansion alone is a contract/API edge change first, not enough by itself to justify a new slice.
- Add glossary terms for API edge, owned data boundary, authority statement, and read model.
- Link the new rule from root index, README, architecture principles, MSA/SaaS replication governance, CLEVER MSA platform pointer, and `msa-template@v1`.
- Keep runtime facts and release evidence out of this repo per `docs/root/doc-governance.md`.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: yes; all changes clarify the same MSA boundary interpretation rule
- same validation command: yes; markdown link/content guards and `git diff --check`
- different app/service/contract surface: no app/runtime surface changes
- merge order dependency: none
- rollback unit: docs governance commits in this PR

## 테스트 여부

- `git diff --check`
- custom markdown link checker across all `*.md`
- content guard for the new doc: no local absolute path, ARN, or image digest identifiers; required MSA boundary terms present
- service candidacy indicator guard: new doc contains `새 runtime slice 추가 가능성 지표`, `authority statement`, `alternatives rejected`, and `release boundary`; proposal is rejected when either core gate field is missing
- subagent governance review: no wiki/context-governance violations found
- subagent consistency review: important wording gaps found and fixed in commit `9b19fd1`
- `clever-context-monorepo` current-repo-maintenance preflight passed before edits

## 검수 포인트

- The new doc must not duplicate `clever-msa-platform` runtime facts.
- The wording should make clear that MSA is not just adding a service, but should still allow a new runtime slice or separate service when responsibility and authority indicators justify it.
- A new runtime slice proposal should be rejected if either authority statement or rejected alternatives are missing.
- API edge alone should remain a contract/API edge change unless responsibility and authority boundaries are explicit.
- Existing product service/runtime slice/workload terminology must remain consistent with `docs/root/domain-glossary.md`.

## rollout/rollback 영향

- No runtime rollout.
- Rollback is reverting this docs PR.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: not applicable for product repo; context repo PR only
- clever-change-control issue: `EVNSolution/clever-change-control#24`
- open PR checked: no open PRs on `EVNSolution/clever-context-monorepo` before creation
- conflict candidates: none found
- user-forced-proceed reason: not applicable

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `README.md`, `docs/root/doc-governance.md`, `docs/root/authority-boundaries.md`, `docs/root/clever-msa-platform-workspace.md`, `docs/root/msa-saas-replication-governance.md`, `docs/templates/msa-template/versions/v1.md`, `../clever-agent-project/AGENTS.md`, `../clever-change-control/README.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: this PR
- linked issue close evidence: not closing `#24`; integration-local-stack follow-up remains open
