### PR TITLE
[codex] Point startup authority to agent-project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local OS/editor artifacts.
+.DS_Store
+**/.DS_Store
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,37 +19,19 @@ Short version:
 - generic startup: redirect to `clever-agent-project`
 - repo-local maintenance: stay in `clever-context-monorepo`
 
-## Workspace Contract
+## Startup Pointer
 
-CLEVER expects a local three-repository workspace:
+The startup/preflight authority lives in `clever-agent-project`. Do not duplicate
+the command, GitHub login prompt, preflight checklist, or `workspace_check`
+branch table here.
 
-1. `clever-agent-project`
-2. `clever-context-monorepo`
-3. `clever-change-control`
+For generic CLEVER startup, move to the sibling `clever-agent-project` checkout
+and follow its `AGENTS.md`. The bootstrap helper there reads the complete local
+three-repository workspace, including this repository.
 
-Before doing real work, run the automatic preflight check from the current session:
-
-```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
-```
-
-If the session is explicitly about editing this repository itself, run:
-
-```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
-```
-
-The preflight must verify `gh auth status`, GitHub login `OziinG`,
-`EVNSolution` org membership, control-plane remotes, clean worktrees, remote
-fetch access, and issue/PR/ruleset read access. If `preflight_check.ready` is
-false, stop before startup work and report the failed checks.
-
-If it is true, interpret `workspace_check.agent_action` like this:
-
-- `proceed-with-hard-gate`: the workspace is complete and startup may continue
-- `current-repo-maintenance`: this repository itself is the target, so stay here
-- `switch-to-clever-agent-project`: this is generic startup work, so move to `clever-agent-project`
-- `stop-and-fix-workspace`: the local workspace is incomplete, so do not continue as if startup were healthy
+For repo-local maintenance, stay in this repository after the
+`clever-agent-project` preflight identifies this repository as the intended
+control-plane maintenance target.
 
 ## What This Repository Owns
 

--- a/docs/root/agent-runtime-governance.md
+++ b/docs/root/agent-runtime-governance.md
@@ -11,25 +11,15 @@
 
 ## Preflight Gate
 
-작업 시작 질문, `project-start` 초안, repo bootstrap, team-work automation으로 내려가기 전에는 `clever-agent-project`의 preflight를 먼저 통과한다.
+The startup/preflight authority lives in `clever-agent-project`. This governance
+document records the ownership boundary only; it does not duplicate the startup
+command, user GitHub-login prompt, preflight checklist, or admin-preflight
+procedure.
 
-```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
-```
-
-preflight는 `gh auth status`, GitHub login `OziinG`, `EVNSolution` org membership, 3레포 로컬 workspace, `EVNSolution/*` origin, clean worktree, remote fetch, issue/PR/ruleset read access를 확인한다.
-
-GitHub admin 권한이 필요한 target repo ruleset/protection 작업 전에는 대상 repo를 지정해 admin preflight를 다시 통과한다.
-
-```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py \
-  --cwd "$PWD" \
-  --admin-preflight \
-  --target-repo-full-name EVNSolution/<target-repo> \
-  --json
-```
-
-새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 membership과 API 접근을 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
+Agents must use `clever-agent-project/AGENTS.md` and its bootstrap helper as the
+canonical startup surface. The helper reads the complete local three-repository
+workspace, so this repository does not need a parallel copy of the startup
+procedure.
 
 ### root intake
 


### PR DESCRIPTION
## Summary

- replace copied startup/preflight commands with a thin pointer to `clever-agent-project`
- document that startup/preflight authority lives in `clever-agent-project`
- keep `clever-context-monorepo` focused on interpretation and governance ownership
- add `.gitignore` coverage for local `.DS_Store` artifacts

This PR is stacked after merged PR #17, so the session changes sit on top of the MSA boundary governance update.

## Validation

- `python3 -m pytest -q` from `clever-agent-project` → `60 passed, 2 skipped`
- `git diff --check` across all three control-plane repos
- sibling doc search confirms no duplicated `--preflight`, `CLEVER_EXPECTED_GITHUB_LOGIN`, `gh auth status`, or stale `OziinG` startup details
