### PR TITLE
Define MSA development repo-template foundation

### DIFF
--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -37,9 +37,10 @@
 
 - status: `candidate`
 - latest version: `v1`
-- use_case: package-style MSA template family registry
-- deploy_profile: `image-build-once-and-promote`
-- summary: MSA archetype family entry for repo/runtime slice templates
+- use_case: MSA umbrella development repository template lineage
+- deploy_profile: `not-applicable-development-template`
+- summary: development repo structure, docs authority, and runtime slice boundary template for MSA product services
+- template_repository: `https://github.com/EVNSolution/clever-msa-repo-template`
 - 문서:
   - [`docs/templates/msa-template/index.md`](./msa-template/index.md)
   - [`docs/templates/msa-template/versions/v1.md`](./msa-template/versions/v1.md)

--- a/docs/templates/msa-template/index.md
+++ b/docs/templates/msa-template/index.md
@@ -4,29 +4,61 @@
 
 이 문서는 `msa-template` family entry다.
 
-MSA product service를 구성하는 repo/runtime slice archetype을 template family로
-묶어 설명한다. 실제 product/runtime 사실은 소유 repo 문서를 따른다.
+MSA product service를 개발하기 위한 **repo-template lineage**를 설명한다.
+여기서 repo-template은 실행형 scaffold나 배포 절차가 아니라, 새 MSA 개발
+저장소가 따라야 하는 루트 구조, 문서 정본, source slice 경계, 개발 운영
+규칙의 기준이다.
+
+실제 product/runtime 사실은 소유 repo 문서를 따른다.
 
 ## Registry 요약
 
 - `template_id`: `msa-template`
 - `current_version`: `v1`
 - `status`: `candidate`
-- `use_case`: package-style MSA template family registry
-- `deploy_profile`: `image-build-once-and-promote`
-- `summary`: MSA archetype family entry for repo/runtime slice templates
-- `allowed_override_boundary`: org naming, repository naming, CI vendor, deploy environment naming, package manager
-- `known_constraints`: scaffold asset and product-specific runtime facts are out of scope
+- `use_case`: MSA umbrella development repository template lineage
+- `deploy_profile`: `not-applicable-development-template`
+- `summary`: development repo structure, docs authority, and runtime slice boundary template for MSA product services
+- `template_repository`: `EVNSolution/clever-msa-repo-template`
+- `allowed_override_boundary`: org naming, repository naming, source-slice naming, docs taxonomy, package manager, local tooling
+- `known_constraints`: executable scaffold assets, deploy process, and product-specific runtime facts are out of scope
 
-## 포함되는 Archetype
+## Template Source Anchors
 
-1. `msa-ops-orchestration-template`
-2. `msa-infra-ecs-template`
-3. `msa-front-web-template`
-4. `msa-edge-gateway-template`
-5. `msa-service-django-template`
-6. `msa-service-read-model-template`
-7. `msa-service-special-runtime-template`
+이 template family는 특정 product 사실을 복제하지 않는다. 현재 GitHub template
+repo artifact와 근거 reference는 아래 pointer를 따른다.
+
+- template repo artifact:
+  `https://github.com/EVNSolution/clever-msa-repo-template`
+- `clever-msa-platform:WORKSPACE.md`
+- `clever-msa-platform:repo-map.md`
+- `clever-msa-platform:docs/mappings/repo-responsibility-matrix.md`
+- `clever-msa-platform:docs/root` equivalent pointer:
+  [`docs/root/clever-msa-platform-workspace.md`](../../root/clever-msa-platform-workspace.md)
+- MSA slice 판단 기준:
+  [`docs/root/msa-boundary-governance.md`](../../root/msa-boundary-governance.md)
+
+## 포함되는 Development Archetype
+
+1. `msa-root-docs-template`
+2. `msa-source-slice-map-template`
+3. `msa-front-slice-template`
+4. `msa-edge-slice-template`
+5. `msa-write-service-slice-template`
+6. `msa-read-model-slice-template`
+7. `msa-worker-or-special-runtime-slice-template`
+
+위 이름은 개발 repo 구조와 책임 분리 기준을 설명하는 archetype label이다.
+특정 framework, cloud runtime, CI/CD vendor, deploy target을 강제하지 않는다.
+
+## Repo-template 기준
+
+- root 문서는 제품의 목표, 경계, mapping, contract, decision의 정본이다.
+- source slice는 product service 안의 책임 단위이며, 물리 repo 수와 동일하지 않을 수 있다.
+- slice 이름은 역할을 드러내야 한다. 예: `front-*`, `edge-*`, `service-*`, 필요 시 `runtime-*`.
+- service slice는 다른 service slice의 내부 구현을 import하지 않는다.
+- repo-local README는 사용법과 운영 메모만 담고, 아키텍처 정본은 root docs를 가리킨다.
+- 새 slice는 책임, owned data boundary, API edge, consumer, 대안 검토가 먼저 설명되어야 한다.
 
 ## Template-only 원칙
 
@@ -34,6 +66,7 @@ MSA product service를 구성하는 repo/runtime slice archetype을 template fam
 
 - business rule 예제
 - 고객/조직 전용 내용
+- deploy workflow, release 절차, CI/CD 구현
 - secret, ARN, internal URL
 - rollout history나 운영 incident 기록
 - 특정 product service의 runtime truth
@@ -44,8 +77,9 @@ MSA product service를 구성하는 repo/runtime slice archetype을 template fam
 아래에 가까우면 소유 repo 문서를 먼저 본다.
 
 - 현재 운영 중인 runtime topology를 판단해야 한다.
-- runtime slice별 rollout/runbook detail이 필요하다.
+- 배포 또는 release runbook detail이 필요하다.
 - 지금 바로 실행형 scaffold가 필요하다.
+- 특정 framework별 service starter code가 필요하다.
 
 ## 버전 문서
 

--- a/docs/templates/msa-template/versions/v1.md
+++ b/docs/templates/msa-template/versions/v1.md
@@ -5,44 +5,122 @@
 - `template_id`: `msa-template`
 - `version`: `v1`
 - `status`: `candidate`
-- `project_type`: `MSA product service family`
-- `deploy_profile`: `image-build-once-and-promote`
+- `project_type`: `MSA umbrella development repository`
+- `deploy_profile`: `not-applicable-development-template`
 
 ## Scope
 
-이 버전은 MSA archetype family를 문서형 template contract로 고정한다.
-MSA slice 분리는 [`docs/root/msa-boundary-governance.md`](../../../root/msa-boundary-governance.md)의
+이 버전은 MSA 개발 저장소를 만들 때 따라야 하는 repo-template contract를
+문서형 기준으로 고정한다. 목적은 배포 절차가 아니라 개발 방식의 재사용이다.
+
+MSA slice 분리는
+[`docs/root/msa-boundary-governance.md`](../../../root/msa-boundary-governance.md)의
 책임·데이터 소유권·API edge 기준을 만족해야 한다.
 
-## Included Archetypes
+## Repo-template Contract
 
-- `msa-ops-orchestration-template`
-- `msa-infra-ecs-template`
-- `msa-front-web-template`
-- `msa-edge-gateway-template`
-- `msa-service-django-template`
-- `msa-service-read-model-template`
-- `msa-service-special-runtime-template`
+새 MSA 개발 repo는 아래 흐름을 기준으로 시작한다.
 
-## Deploy Safety Boundary
+```text
+product intent
+-> root docs authority
+-> source slice map
+-> responsibility / non-responsibility matrix
+-> contracts and API edge notes
+-> slice-local implementation
+```
 
-- build와 deploy의 역할을 분리한다.
-- artifact는 immutable tag로 고정한다.
-- verification과 release는 같은 artifact를 재사용한다.
-- env, secret, health path, port, upstream name 같은 deploy contract는 명시적으로 관리한다.
-- service를 붙이는 것만으로 workload가 되지 않으며, 책임과 release boundary가 같이 문서화되어야 한다.
+구현은 source slice 안에서 진행하지만, 경계와 mapping의 정본은 root docs가
+소유한다.
+
+## Baseline Repository Shape
+
+이 template은 아래 형태를 권장한다. 디렉터리 이름은 조직별로 바꿀 수 있지만,
+역할은 유지해야 한다.
+
+```text
+<product>-msa-platform/
+├── WORKSPACE.md
+├── repo-map.md
+├── docs/
+│   ├── goals/
+│   ├── boundaries/
+│   ├── mappings/
+│   ├── contracts/
+│   ├── decisions/
+│   └── archive/
+└── development/
+    ├── front-*
+    ├── edge-*
+    ├── service-*
+    └── runtime-*        # optional, only when a non-service operational slice is justified
+```
+
+### Root files
+
+- `WORKSPACE.md`: repo-template의 전체 목적, top-level directory 역할, 작업 규칙
+- `repo-map.md`: source slice 이름, category, 역할, 현재 상태, 정본 문서 pointer
+- `docs/`: 목표, 경계, mapping, contract, decision의 canonical location
+- `development/`: 실제 구현 source slice
+
+### Source slice families
+
+- `front-*`: 사용자 UI 또는 client surface
+- `edge-*`: routing, public/internal edge, API exposure, auth handoff
+- `service-*`: business capability 또는 read model ownership
+- `runtime-*`: product service 구현이 아니라 platform operation 또는 non-service control 책임이 문서로 정당화된 경우에만 사용
+
+## Development Rules
+
+- 문서가 먼저이고 source slice는 그 다음이다.
+- 새 slice는 책임 문장, owned data boundary, API edge, consumer, 대안을 먼저 남긴다.
+- write authority는 한 slice가 소유한다.
+- read model slice는 원천 데이터를 직접 쓰지 않는다.
+- service slice끼리는 내부 application code를 import하지 않는다.
+- 공유 코드는 기본 금지이며, 필요하면 contract를 먼저 분리한다.
+- slice-local README는 사용법과 운영 메모만 담고, architecture truth를 복제하지 않는다.
+- root docs와 slice README가 충돌하면 root docs를 우선한다.
+
+## Included Development Archetypes
+
+- `msa-root-docs-template`
+- `msa-source-slice-map-template`
+- `msa-front-slice-template`
+- `msa-edge-slice-template`
+- `msa-write-service-slice-template`
+- `msa-read-model-slice-template`
+- `msa-worker-or-special-runtime-slice-template`
+
+각 archetype은 responsibility shape를 설명하기 위한 이름이다. 특정 framework,
+cloud service, deployment tool, database 제품을 강제하지 않는다.
+
+## Adoption Checklist
+
+새 repo-template 채택 시 최소 아래를 확인한다.
+
+1. product service가 무엇인지 설명되어 있다.
+2. root docs가 canonical authority임을 명시한다.
+3. source slice 목록과 category가 `repo-map.md`에 있다.
+4. 각 slice의 `owns / does not own / depends on`이 문서화되어 있다.
+5. cross-slice import 금지와 contract-first 원칙이 적혀 있다.
+6. service implementation detail과 business sample data가 template 본문에 들어가지 않는다.
+7. 배포 절차와 runtime proof가 개발 repo-template 본문에 섞이지 않는다.
 
 ## Excluded
 
 - sample business data
-- 조직별 naming 규칙
+- concrete service starter code
+- framework-specific implementation skeleton
+- 조직별 naming 규칙의 실제 값
 - internal URL, ARN, secret naming
 - 현재 운영 중인 runtime topology
+- deploy workflow, release lane, CI/CD workflow detail
 - runtime slice별 rollout/runbook detail
 - runtime proof 또는 host sizing evidence
 
 ## Known Constraints
 
 - 이 버전은 concrete scaffold 파일을 제공하지 않는다.
-- leaf template는 이후 독립 entry로 분리될 수 있다.
+- leaf implementation template는 이후 독립 entry로 분리될 수 있다.
+- deploy lineage가 필요하면 별도 deploy template family에서 다룬다.
 - 실제 채택 결과는 소유 repo와 change-control에서 추적한다.


### PR DESCRIPTION
## Summary

- Reframes `msa-template` as a development repo-template lineage, not a deploy template.
- Links the created GitHub template repository: https://github.com/EVNSolution/clever-msa-repo-template
- Documents docs-first source slice governance, root authority, and slice boundary rules for MSA umbrella repositories.

## Validation

- `git diff --check`
- grep scan confirmed ECR/OIDC/GitHub Actions/superpowers are not introduced into the MSA template body.
- Verified GitHub repo `EVNSolution/clever-msa-repo-template` has `isTemplate=true`.

## Notes

- Deployment lineage remains separate in `Clever-OIDC-deploy`.
- This PR intentionally does not add service starter code or runtime proof.
