### PR TITLE
Add driver app service context pointers

### DIFF
--- a/docs/services/clever-delivery-server/index.md
+++ b/docs/services/clever-delivery-server/index.md
@@ -1,0 +1,55 @@
+# clever-delivery-server Context Pointer
+
+## Purpose
+
+This file records the canonical context pointer for the `clever-delivery-server`
+backend runtime. It does not copy API payloads, runtime proof, secrets,
+environment values, deployment evidence, or object-storage credentials from the
+target repository.
+
+## Registry
+
+| Field | Value |
+| --- | --- |
+| service_id | `clever-delivery-server` |
+| owner_repo | `EVNSolution/clever-delivery-server` |
+| product_scope | Shopify companion delivery data server and driver API for shops, orders, routes, drivers, consent records, driver events, proof-media metadata/storage contracts, and retention cleanup |
+| current_mvp_anchor | `EVNSolution/clever-change-control#99`, `EVNSolution/clever-delivery-server#71` |
+| context_issue | `EVNSolution/clever-context-monorepo#23` for driver-app release boundary linkage |
+| target_runtime_docs | `EVNSolution/clever-delivery-server:README.md`, `docs/project-brief.md`, `docs/api/driver-proof-media.md`, `docs/compliance/location-data-handling.md`, `docs/deployment/ec2-ebs.md` |
+| deploy_lineage | Node/TypeScript Fastify service; EC2 + EBS PostgreSQL first, RDS/S3 path as scale or proof-media requirements demand |
+| related_mobile_runtime | `EVNSolution/clever-driver-app` |
+
+## Interpretation
+
+- The server is the data and authorization source for the driver app. The driver
+  app must not call Shopify directly for route/order data.
+- Driver-facing APIs currently cover route+phone access, consent records,
+  assigned-route reads, driver events, proof-media upload metadata/storage, scoped
+  short-lived proof-media read access, scanner rejection hooks, scan monitoring
+  hooks, and retention cleanup run evidence.
+- Detailed API contracts, database schema, exact runtime environment variables,
+  secret categories, object-storage provider settings, deployment commands, and
+  proof/evidence records remain in the target repository and change-control.
+- Target-repo docs now include an opt-in S3-compatible proof-media storage backend
+  with SigV4 PUT/DELETE signing and presigned read access. Production bucket/IAM
+  approval, credential custody, live signed URL smoke, scanner deployment,
+  scanner alerting, cleanup scheduler deployment, and private evidence storage
+  remain target-repo/change-control gates.
+
+## Do not store here
+
+- Shopify Admin tokens, JWT secrets, database credentials, S3 access keys,
+  session tokens, bucket names used in production, or connection strings
+- Full API schemas, Prisma schema copies, route inventories, or env matrices
+- Proof images, proof-media storage keys, scanner logs, cleanup job logs, or
+  production evidence manifests
+- Per-run deploy, backup, scheduler, scanner, or signed URL smoke evidence
+
+## Source-of-truth pointers
+
+- Target repository README: `EVNSolution/clever-delivery-server:README.md`
+- Service project brief: `EVNSolution/clever-delivery-server:docs/project-brief.md`
+- Driver proof-media API and storage contract: `EVNSolution/clever-delivery-server:docs/api/driver-proof-media.md`
+- Location/proof data handling: `EVNSolution/clever-delivery-server:docs/compliance/location-data-handling.md`
+- EC2/EBS deployment and proof-media scheduler notes: `EVNSolution/clever-delivery-server:docs/deployment/ec2-ebs.md`

--- a/docs/services/clever-driver-app/index.md
+++ b/docs/services/clever-driver-app/index.md
@@ -1,0 +1,59 @@
+# clever-driver-app Context Pointer
+
+## Purpose
+
+This file records the canonical context pointer for the `clever-driver-app`
+mobile runtime. It does not copy runtime proof, store evidence, secrets,
+environment values, or release artifacts from the target repository.
+
+## Registry
+
+| Field | Value |
+| --- | --- |
+| service_id | `clever-driver-app` |
+| owner_repo | `EVNSolution/clever-driver-app` |
+| product_scope | native iPhone/Android delivery driver app for route access, consent, assigned-route view, active-delivery location tracking, proof capture, offline retry, and route completion cleanup |
+| current_mvp_anchor | `EVNSolution/clever-change-control#145`, `EVNSolution/clever-driver-app#72`, `EVNSolution/clever-driver-app#73` |
+| context_issue | `EVNSolution/clever-context-monorepo#23` |
+| target_runtime_docs | `EVNSolution/clever-driver-app:README.md`, `docs/project-brief.md`, `docs/route-access-flow.md`, `docs/release-readiness.md`, `docs/physical-device-smoke-runbook.md` |
+| related_backend | `EVNSolution/clever-delivery-server`, especially driver route/proof-media API docs |
+| platform_lineage | Expo / React Native native iOS and Android app bootstrap under CLEVER target-repo workflow |
+
+## Interpretation
+
+- The app is a native mobile runtime, not a PWA/web-first driver surface,
+  because active delivery needs OS location permissions, foreground/background
+  tracking behavior, secure token storage, camera/photo/barcode proof capture,
+  and controlled distribution evidence.
+- Route+phone lookup is only an access starting point. Phone number alone is not
+  a global driver identity; company/route context and server-issued short-lived
+  driver access are part of the boundary.
+- The app owns driver-facing UX, native permission prompts, SecureStore token
+  handling, app-side offline retry/discard behavior, and mobile release evidence
+  runbooks. It does not own Shopify data, route assignment authority, proof-media
+  metadata persistence, or object-storage credentials.
+- `clever-delivery-server` owns companies/shops, drivers, route assignments,
+  consent records, driver events, proof-media metadata/storage contracts, and
+  cleanup evidence. The driver app must use the server driver APIs rather than
+  Shopify APIs directly.
+- Production release still requires target-repo evidence for physical iOS/Android
+  device smoke, owner-controlled Expo/EAS/Apple/Google signing and distribution,
+  owner/legal privacy disclosure approval, public license decision, and related
+  delivery-server proof-media hardening evidence.
+
+## Do not store here
+
+- App Store / Google Play screenshots, review answers, signing files, or private
+  distribution evidence
+- Driver phone numbers, route data, customer addresses, proof images, or logs
+- Expo/EAS project IDs, Apple/Google credentials, API origins, or runtime env
+  values copied from the target repository
+- Per-PR status, build artifacts, or smoke evidence manifests
+
+## Source-of-truth pointers
+
+- Target repository README: `EVNSolution/clever-driver-app:README.md`
+- Product brief and scenario plan: `EVNSolution/clever-driver-app:docs/project-brief.md`
+- App-side API/runtime flow: `EVNSolution/clever-driver-app:docs/route-access-flow.md`
+- Release readiness and evidence gates: `EVNSolution/clever-driver-app:docs/release-readiness.md`
+- Physical-device smoke runbook: `EVNSolution/clever-driver-app:docs/physical-device-smoke-runbook.md`

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -23,4 +23,6 @@ runtime slice 정본은 아래를 따른다.
 
 | service_id | owner_repo | context pointer | current anchor | template lineage |
 | --- | --- | --- | --- | --- |
+| `clever-delivery-server` | `EVNSolution/clever-delivery-server` | [`docs/services/clever-delivery-server/index.md`](./clever-delivery-server/index.md) | `EVNSolution/clever-delivery-server#71`, `EVNSolution/clever-change-control#99` | `node-ec2-delivery-server@0.1.0 / ec2-ebs-postgres / adopt` |
+| `clever-driver-app` | `EVNSolution/clever-driver-app` | [`docs/services/clever-driver-app/index.md`](./clever-driver-app/index.md) | `EVNSolution/clever-change-control#145`, `EVNSolution/clever-driver-app#72`, `EVNSolution/clever-driver-app#73` | Expo / React Native native iOS and Android app bootstrap |
 | `thundercrew-domain` | `EVNSolution/thundercrew-domain` | [`docs/services/thundercrew-domain/index.md`](./thundercrew-domain/index.md) | `EVNSolution/thundercrew-domain#106`, `EVNSolution/clever-change-control#98` | `Clever-OIDC-deploy` with existing-EC2 override; `msa-template` boundary principles |


### PR DESCRIPTION
## Summary

Add durable service-context pointers for the driver native app and its delivery-server backend boundary.

## Scope

- Add `docs/services/clever-driver-app/index.md` as a pointer to the driver app target repo docs, release evidence gates, and backend boundary.
- Add `docs/services/clever-delivery-server/index.md` as a pointer to the delivery-server target repo docs, driver API/proof-media ownership, and remaining production proof-media evidence gates.
- Update `docs/services/index.md` registry rows for both services.

## Context policy

This PR intentionally does not copy runtime env matrices, API schemas, secrets, object-storage credentials, store evidence, smoke evidence, or PR status into `clever-context-monorepo`. It only records durable ownership/boundary/source-of-truth pointers.

## Validation

- `git diff --check` — pass
- `git diff --cached --check` — pass before commit
- context service pointer sanity script — pass

## Linked issues

- Refs EVNSolution/clever-context-monorepo#23
- Refs EVNSolution/clever-change-control#145
- Refs EVNSolution/clever-delivery-server#71
- Refs EVNSolution/clever-delivery-server#76

## Issue closure

Do not close #23 automatically if maintainers want to keep it open until final physical-device/store/evidence gates are complete. This PR provides the current canonical pointer layer and records remaining target-repo evidence gates.
