### PR TITLE
[codex] Point context wiki at current CLEVER product runtimes

### DIFF
--- a/docs/root/doc-governance.md
+++ b/docs/root/doc-governance.md
@@ -28,7 +28,7 @@
 
 아래는 이 repo에 만들지 않는다.
 
-- `docs/services/<slice>/index.md`
+- target repo 상세를 복제하는 `docs/services/<slice>/index.md`
 - 작업 계획이나 implementation plan
 - 진행 중 design draft
 - runtime current status

--- a/docs/services/clever-delivery-server/index.md
+++ b/docs/services/clever-delivery-server/index.md
@@ -2,54 +2,61 @@
 
 ## Purpose
 
-This file records the canonical context pointer for the `clever-delivery-server`
-backend runtime. It does not copy API payloads, runtime proof, secrets,
-environment values, deployment evidence, or object-storage credentials from the
-target repository.
+This file records the canonical context pointer for the CLEVER delivery API
+runtime. It does not copy API payloads, runtime proof, secrets, environment
+values, deployment evidence, or object-storage credentials from the target
+repository.
 
 ## Registry
 
 | Field | Value |
 | --- | --- |
 | service_id | `clever-delivery-server` |
-| owner_repo | `EVNSolution/clever-delivery-server` |
-| product_scope | Shopify companion delivery data server and driver API for shops, orders, routes, drivers, consent records, driver events, proof-media metadata/storage contracts, and retention cleanup |
-| current_mvp_anchor | `EVNSolution/clever-change-control#99`, `EVNSolution/clever-delivery-server#71` |
-| context_issue | `EVNSolution/clever-context-monorepo#23` for driver-app release boundary linkage |
-| target_runtime_docs | `EVNSolution/clever-delivery-server:README.md`, `docs/project-brief.md`, `docs/api/driver-proof-media.md`, `docs/compliance/location-data-handling.md`, `docs/deployment/ec2-ebs.md` |
-| deploy_lineage | Node/TypeScript Fastify service; EC2 + EBS PostgreSQL first, RDS/S3 path as scale or proof-media requirements demand |
-| related_mobile_runtime | `EVNSolution/clever-driver-app` |
+| owner_repo | <https://github.com/EVNSolution/shopify-clever> |
+| runtime_source | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api> |
+| product_scope | Shopify companion delivery data server and driver API for shops, orders, routes, drivers, invite/auth flows, consent records, driver events, proof-media metadata/storage contracts, and retention cleanup |
+| target_runtime_docs | <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/README.md> and <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api/docs> |
+| deploy_lineage | Node/TypeScript Fastify service with Prisma/PostgreSQL, deployed as the delivery API runtime paired with the Shopify embedded app |
+| related_shopify_admin | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app> |
+| related_mobile_runtime | <https://github.com/EVNSolution/clever-driver-app> |
 
 ## Interpretation
 
-- The server is the data and authorization source for the driver app. The driver
-  app must not call Shopify directly for route/order data.
-- Driver-facing APIs currently cover route+phone access, consent records,
-  assigned-route reads, driver events, proof-media upload metadata/storage, scoped
-  short-lived proof-media read access, scanner rejection hooks, scan monitoring
-  hooks, and retention cleanup run evidence.
+- The server is the data and authorization source for the Shopify admin app and
+  the driver app. The driver app must not call Shopify directly for route/order
+  data.
+- Admin-facing APIs cover delivery orders, route planning, route assignment,
+  driver invite/access operations, and synchronization boundaries used by the
+  Shopify embedded app.
+- Driver-facing APIs cover invite verification, bearer access, consent records,
+  assigned-route reads, driver events, proof-media upload metadata/storage,
+  scoped proof-media read access, scan rejection hooks, monitoring hooks, and
+  retention cleanup evidence.
 - Detailed API contracts, database schema, exact runtime environment variables,
   secret categories, object-storage provider settings, deployment commands, and
   proof/evidence records remain in the target repository and change-control.
-- Target-repo docs now include an opt-in S3-compatible proof-media storage backend
-  with SigV4 PUT/DELETE signing and presigned read access. Production bucket/IAM
-  approval, credential custody, live signed URL smoke, scanner deployment,
-  scanner alerting, cleanup scheduler deployment, and private evidence storage
-  remain target-repo/change-control gates.
 
 ## Do not store here
 
-- Shopify Admin tokens, JWT secrets, database credentials, S3 access keys,
-  session tokens, bucket names used in production, or connection strings
+- Shopify Admin tokens, JWT secrets, database credentials, object-storage access
+  keys, session tokens, bucket names used in production, or connection strings
 - Full API schemas, Prisma schema copies, route inventories, or env matrices
 - Proof images, proof-media storage keys, scanner logs, cleanup job logs, or
   production evidence manifests
 - Per-run deploy, backup, scheduler, scanner, or signed URL smoke evidence
+- Local filesystem paths or machine-specific URLs
 
 ## Source-of-truth pointers
 
-- Target repository README: `EVNSolution/clever-delivery-server:README.md`
-- Service project brief: `EVNSolution/clever-delivery-server:docs/project-brief.md`
-- Driver proof-media API and storage contract: `EVNSolution/clever-delivery-server:docs/api/driver-proof-media.md`
-- Location/proof data handling: `EVNSolution/clever-delivery-server:docs/compliance/location-data-handling.md`
-- EC2/EBS deployment and proof-media scheduler notes: `EVNSolution/clever-delivery-server:docs/deployment/ec2-ebs.md`
+- Target repository: <https://github.com/EVNSolution/shopify-clever>
+- Delivery API runtime source: <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api>
+- Delivery API README: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/README.md>
+- Service project brief: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/project-brief.md>
+- API documentation strategy: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/README.md>
+- OpenAPI contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/openapi.yaml>
+- Admin route plans contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/admin-route-plans.md>
+- Driver route access contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/driver-route-access.md>
+- Driver assigned route contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/driver-assigned-route.md>
+- Driver proof-media API and storage contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/driver-proof-media.md>
+- Location/proof data handling: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/compliance/location-data-handling.md>
+- EC2/EBS deployment notes: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/deployment/ec2-ebs.md>

--- a/docs/services/clever-driver-app/index.md
+++ b/docs/services/clever-driver-app/index.md
@@ -11,12 +11,14 @@ environment values, or release artifacts from the target repository.
 | Field | Value |
 | --- | --- |
 | service_id | `clever-driver-app` |
-| owner_repo | `EVNSolution/clever-driver-app` |
-| product_scope | native iPhone/Android delivery driver app for route access, consent, assigned-route view, active-delivery location tracking, proof capture, offline retry, and route completion cleanup |
-| current_mvp_anchor | `EVNSolution/clever-change-control#145`, `EVNSolution/clever-driver-app#72`, `EVNSolution/clever-driver-app#73` |
-| context_issue | `EVNSolution/clever-context-monorepo#23` |
-| target_runtime_docs | `EVNSolution/clever-driver-app:README.md`, `docs/project-brief.md`, `docs/route-access-flow.md`, `docs/release-readiness.md`, `docs/physical-device-smoke-runbook.md` |
-| related_backend | `EVNSolution/clever-delivery-server`, especially driver route/proof-media API docs |
+| owner_repo | <https://github.com/EVNSolution/clever-driver-app> |
+| runtime_source | <https://github.com/EVNSolution/clever-driver-app/tree/dev> |
+| product_scope | native iPhone/Android delivery driver app for invite-based access, driver identity, consent, assigned-route view, active-delivery location tracking, proof capture, offline retry, and route completion cleanup |
+| current_mvp_anchor | <https://github.com/EVNSolution/clever-change-control/issues/145>, <https://github.com/EVNSolution/clever-driver-app/issues/72>, <https://github.com/EVNSolution/clever-driver-app/issues/73> |
+| context_issue | <https://github.com/EVNSolution/clever-context-monorepo/issues/23> |
+| target_runtime_docs | <https://github.com/EVNSolution/clever-driver-app/blob/dev/README.md> and <https://github.com/EVNSolution/clever-driver-app/tree/dev/docs> |
+| related_backend | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api> |
+| related_shopify_admin | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app> |
 | platform_lineage | Expo / React Native native iOS and Android app bootstrap under CLEVER target-repo workflow |
 
 ## Interpretation
@@ -25,21 +27,19 @@ environment values, or release artifacts from the target repository.
   because active delivery needs OS location permissions, foreground/background
   tracking behavior, secure token storage, camera/photo/barcode proof capture,
   and controlled distribution evidence.
-- Route+phone lookup is only an access starting point. Phone number alone is not
-  a global driver identity; company/route context and server-issued short-lived
-  driver access are part of the boundary.
+- Invite-code verification and phone identity are app entry mechanisms, not a
+  replacement for server-issued driver access and tenant/shop scoping.
 - The app owns driver-facing UX, native permission prompts, SecureStore token
   handling, app-side offline retry/discard behavior, and mobile release evidence
-  runbooks. It does not own Shopify data, route assignment authority, proof-media
-  metadata persistence, or object-storage credentials.
-- `clever-delivery-server` owns companies/shops, drivers, route assignments,
+  runbooks. It does not own Shopify data, route assignment authority,
+  proof-media metadata persistence, or object-storage credentials.
+- The paired delivery API owns companies/shops, drivers, route assignments,
   consent records, driver events, proof-media metadata/storage contracts, and
   cleanup evidence. The driver app must use the server driver APIs rather than
   Shopify APIs directly.
-- Production release still requires target-repo evidence for physical iOS/Android
-  device smoke, owner-controlled Expo/EAS/Apple/Google signing and distribution,
-  owner/legal privacy disclosure approval, public license decision, and related
-  delivery-server proof-media hardening evidence.
+- Future app-tab server work should be exposed as delivery API contracts before
+  the app treats route history, earnings, profile update, or account deletion as
+  live server-backed features.
 
 ## Do not store here
 
@@ -49,11 +49,15 @@ environment values, or release artifacts from the target repository.
 - Expo/EAS project IDs, Apple/Google credentials, API origins, or runtime env
   values copied from the target repository
 - Per-PR status, build artifacts, or smoke evidence manifests
+- Local filesystem paths or machine-specific URLs
 
 ## Source-of-truth pointers
 
-- Target repository README: `EVNSolution/clever-driver-app:README.md`
-- Product brief and scenario plan: `EVNSolution/clever-driver-app:docs/project-brief.md`
-- App-side API/runtime flow: `EVNSolution/clever-driver-app:docs/route-access-flow.md`
-- Release readiness and evidence gates: `EVNSolution/clever-driver-app:docs/release-readiness.md`
-- Physical-device smoke runbook: `EVNSolution/clever-driver-app:docs/physical-device-smoke-runbook.md`
+- Target repository: <https://github.com/EVNSolution/clever-driver-app>
+- Runtime source branch: <https://github.com/EVNSolution/clever-driver-app/tree/dev>
+- Target repository README: <https://github.com/EVNSolution/clever-driver-app/blob/dev/README.md>
+- Product brief and scenario plan: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/project-brief.md>
+- App-side API/runtime flow: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/route-access-flow.md>
+- Release readiness and evidence gates: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/release-readiness.md>
+- Physical-device smoke runbook: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/physical-device-smoke-runbook.md>
+- Expo app identity config: <https://github.com/EVNSolution/clever-driver-app/blob/dev/app.json>

--- a/docs/services/clever-shopify-app/index.md
+++ b/docs/services/clever-shopify-app/index.md
@@ -1,0 +1,56 @@
+# clever-shopify-app Context Pointer
+
+## Purpose
+
+This file records the canonical context pointer for the CLEVER Shopify embedded
+admin app runtime. It does not copy Shopify dashboard state, review evidence,
+Admin API payloads, credentials, environment values, or release artifacts from
+the target repository.
+
+## Registry
+
+| Field | Value |
+| --- | --- |
+| service_id | `clever-shopify-app` |
+| owner_repo | <https://github.com/EVNSolution/shopify-clever> |
+| runtime_source | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app> |
+| product_scope | Shopify embedded admin app for CLEVER merchants: order intake, delivery-date filtering, route planning, route detail, driver invite/access, and operational navigation surfaces |
+| naming_authority | <https://github.com/EVNSolution/shopify-clever/blob/main/NAMING.md> |
+| paired_delivery_api | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api> |
+| related_mobile_runtime | <https://github.com/EVNSolution/clever-driver-app> |
+| deploy_lineage | React Router Shopify embedded app, Prisma session storage, Shopify CLI config split for production/public and dev/custom-store runtimes |
+
+## Interpretation
+
+- The merchant-facing product name is `CLEVER`; Shopify handle, Admin path, and
+  hosted app URL are separate identity fields and must be checked in the naming
+  authority before release or dashboard changes.
+- The Shopify app owns merchant/admin UX, Shopify authentication/session storage,
+  order synchronization entry points, route planning UI, driver invite/admin
+  actions, and App Store review-facing behavior.
+- The Shopify app must not become the long-term source of driver mobile runtime
+  state. Driver identity, route assignment authority, driver bearer auth,
+  proof-media metadata, and mobile driver APIs belong to the paired delivery API.
+- Public production and dev/custom-store runtimes are intentionally split in the
+  target repository so routine development does not mutate the production app
+  configuration by accident.
+
+## Do not store here
+
+- Shopify Admin tokens, session tokens, API secrets, app secrets, installation
+  tokens, store-specific private evidence, or dashboard payload snapshots
+- Full GraphQL query inventories, API schemas, Prisma schema copies, env matrices,
+  or App Store submission evidence
+- Per-run deploy output, screenshots, screencasts, or review conversation logs
+- Local filesystem paths or machine-specific URLs
+
+## Source-of-truth pointers
+
+- Target repository: <https://github.com/EVNSolution/shopify-clever>
+- Monorepo README: <https://github.com/EVNSolution/shopify-clever/blob/main/README.md>
+- Shopify app runtime source: <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app>
+- Shopify app README: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/shopify-app/README.md>
+- Naming guide: <https://github.com/EVNSolution/shopify-clever/blob/main/NAMING.md>
+- Production Shopify config: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/shopify-app/shopify.app.toml>
+- Dev/custom Shopify config: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/shopify-app/shopify.app.dev.toml>
+- App Store asset packet entry: <https://github.com/EVNSolution/shopify-clever/blob/main/docs/shopify-app-store-assets/README.md>

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -21,8 +21,9 @@ runtime slice 정본은 아래를 따른다.
 
 ## Product service pointers
 
-| service_id | owner_repo | context pointer | current anchor | template lineage |
+| service_id | owner_repo | context pointer | current authority | template lineage |
 | --- | --- | --- | --- | --- |
-| `clever-delivery-server` | `EVNSolution/clever-delivery-server` | [`docs/services/clever-delivery-server/index.md`](./clever-delivery-server/index.md) | `EVNSolution/clever-delivery-server#71`, `EVNSolution/clever-change-control#99` | `node-ec2-delivery-server@0.1.0 / ec2-ebs-postgres / adopt` |
-| `clever-driver-app` | `EVNSolution/clever-driver-app` | [`docs/services/clever-driver-app/index.md`](./clever-driver-app/index.md) | `EVNSolution/clever-change-control#145`, `EVNSolution/clever-driver-app#72`, `EVNSolution/clever-driver-app#73` | Expo / React Native native iOS and Android app bootstrap |
-| `thundercrew-domain` | `EVNSolution/thundercrew-domain` | [`docs/services/thundercrew-domain/index.md`](./thundercrew-domain/index.md) | `EVNSolution/thundercrew-domain#106`, `EVNSolution/clever-change-control#98` | `Clever-OIDC-deploy` with existing-EC2 override; `msa-template` boundary principles |
+| `clever-driver-app` | <https://github.com/EVNSolution/clever-driver-app> | <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/clever-driver-app/index.md> | <https://github.com/EVNSolution/clever-driver-app/tree/dev> | Expo / React Native native iOS and Android app bootstrap |
+| `clever-shopify-app` | <https://github.com/EVNSolution/shopify-clever> | <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/clever-shopify-app/index.md> | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app> and <https://github.com/EVNSolution/shopify-clever/blob/main/NAMING.md> | React Router Shopify embedded admin app paired with delivery API |
+| `clever-delivery-server` | <https://github.com/EVNSolution/shopify-clever> | <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/clever-delivery-server/index.md> | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api> | Fastify / Prisma delivery API runtime paired with Shopify admin and driver app |
+| `thundercrew-domain` | `EVNSolution/thundercrew-domain` | <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/thundercrew-domain/index.md> | `EVNSolution/thundercrew-domain#106`, `EVNSolution/clever-change-control#98` | `Clever-OIDC-deploy` with existing-EC2 override; `msa-template` boundary principles |

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -13,3 +13,13 @@ summary를 올리지 않는다. 빠른 탐색이 필요하면 아래 완료 문�
 - [`docs/templates/index.md`](../templates/index.md)
 
 제품, platform, runtime slice 사실은 소유 repo의 정본 문서를 직접 본다.
+
+## Current product entrypoints
+
+제품 runtime 정보를 찾을 때는 아래 pointer를 먼저 보고, 실제 상세 사실은 연결된
+GitHub 정본 문서에서 확인한다.
+
+- Service pointer table: <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/index.md>
+- Mobile driver app: <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/clever-driver-app/index.md>
+- Shopify embedded app: <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/clever-shopify-app/index.md>
+- Delivery API server: <https://github.com/EVNSolution/clever-context-monorepo/blob/main/docs/services/clever-delivery-server/index.md>


### PR DESCRIPTION
## Summary

- Add a pointer-only context page for the CLEVER Shopify embedded app.
- Repoint the delivery API server entry to the `shopify-clever` delivery runtime source.
- Repoint the driver mobile app entry to the `clever-driver-app` GitHub source branch.
- Add wiki entrypoints for mobile app, Shopify app, and delivery API server.

## Why

The context monorepo should help agents find the current product runtimes without copying service details or embedding local machine paths.

## Validation

- `git diff --check`
- local absolute path scan for `/Users`, `Documents/Files`, `01_Repos`, `04_CLEVER`, `00_CLEVER`, `localhost`, and `127.0.0.1`
- GitHub pointer validation for 54 URLs
- `omx wiki wiki_lint --json`
