### PR TITLE
Keep driver account and store display names distinct

### DIFF
--- a/docs/services/clever-delivery-server/index.md
+++ b/docs/services/clever-delivery-server/index.md
@@ -12,10 +12,10 @@ repository.
 | Field | Value |
 | --- | --- |
 | service_id | `clever-delivery-server` |
-| owner_repo | <https://github.com/EVNSolution/shopify-clever> |
-| runtime_source | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api> |
-| product_scope | Shopify companion delivery data server and driver API for shops, orders, routes, drivers, invite/auth flows, consent records, driver events, proof-media metadata/storage contracts, and retention cleanup |
-| target_runtime_docs | <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/README.md> and <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api/docs> |
+| owner_repo | <https://github.com/EVNSolution/clever-route-server> |
+| runtime_source | <https://github.com/EVNSolution/clever-route-server/tree/main/apps/delivery-api> |
+| product_scope | delivery data server and driver API for shops, orders, routes, drivers, invite/auth flows, account profiles, consent records, driver events, proof-media metadata/storage contracts, and retention cleanup |
+| target_runtime_docs | <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/README.md> and <https://github.com/EVNSolution/clever-route-server/tree/main/apps/delivery-api/docs> |
 | deploy_lineage | Node/TypeScript Fastify service with Prisma/PostgreSQL, deployed as the delivery API runtime paired with the Shopify embedded app |
 | related_shopify_admin | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app> |
 | related_mobile_runtime | <https://github.com/EVNSolution/clever-driver-app> |
@@ -32,6 +32,9 @@ repository.
   assigned-route reads, driver events, proof-media upload metadata/storage,
   scoped proof-media read access, scan rejection hooks, monitoring hooks, and
   retention cleanup evidence.
+- A driver's phone-owned account name is global across shops. A Shopify store's
+  `Driver.displayName` is a separate merchant-scoped alias; the server does not
+  synchronize or backfill either value into the other.
 - Detailed API contracts, database schema, exact runtime environment variables,
   secret categories, object-storage provider settings, deployment commands, and
   proof/evidence records remain in the target repository and change-control.
@@ -48,15 +51,16 @@ repository.
 
 ## Source-of-truth pointers
 
-- Target repository: <https://github.com/EVNSolution/shopify-clever>
-- Delivery API runtime source: <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api>
-- Delivery API README: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/README.md>
-- Service project brief: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/project-brief.md>
-- API documentation strategy: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/README.md>
-- OpenAPI contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/openapi.yaml>
-- Admin route plans contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/admin-route-plans.md>
-- Driver route access contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/driver-route-access.md>
-- Driver assigned route contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/driver-assigned-route.md>
-- Driver proof-media API and storage contract: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/api/driver-proof-media.md>
-- Location/proof data handling: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/compliance/location-data-handling.md>
-- EC2/EBS deployment notes: <https://github.com/EVNSolution/shopify-clever/blob/main/apps/delivery-api/docs/deployment/ec2-ebs.md>
+- Target repository: <https://github.com/EVNSolution/clever-route-server>
+- Delivery API runtime source: <https://github.com/EVNSolution/clever-route-server/tree/main/apps/delivery-api>
+- Delivery API README: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/README.md>
+- Service project brief: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/project-brief.md>
+- API documentation strategy: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/README.md>
+- OpenAPI contract: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/openapi.yaml>
+- Driver authentication and account profile contract: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/driver-auth.md>
+- Admin route plans contract: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/admin-route-plans.md>
+- Driver route access contract: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/driver-route-access.md>
+- Driver assigned route contract: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/driver-assigned-route.md>
+- Driver proof-media API and storage contract: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/driver-proof-media.md>
+- Location/proof data handling: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/compliance/location-data-handling.md>
+- EC2/EBS deployment notes: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/deployment/ec2-ebs.md>

--- a/docs/services/clever-driver-app/index.md
+++ b/docs/services/clever-driver-app/index.md
@@ -17,7 +17,7 @@ environment values, or release artifacts from the target repository.
 | current_mvp_anchor | <https://github.com/EVNSolution/clever-change-control/issues/145>, <https://github.com/EVNSolution/clever-driver-app/issues/72>, <https://github.com/EVNSolution/clever-driver-app/issues/73> |
 | context_issue | <https://github.com/EVNSolution/clever-context-monorepo/issues/23> |
 | target_runtime_docs | <https://github.com/EVNSolution/clever-driver-app/blob/dev/README.md> and <https://github.com/EVNSolution/clever-driver-app/tree/dev/docs> |
-| related_backend | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api> |
+| related_backend | <https://github.com/EVNSolution/clever-route-server/tree/main/apps/delivery-api> |
 | related_shopify_admin | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app> |
 | platform_lineage | Expo / React Native native iOS and Android app bootstrap under CLEVER target-repo workflow |
 
@@ -29,6 +29,9 @@ environment values, or release artifacts from the target repository.
   and controlled distribution evidence.
 - Invite-code verification and phone identity are app entry mechanisms, not a
   replacement for server-issued driver access and tenant/shop scoping.
+- The phone-owned driver account name is global across shops. Each Shopify
+  store's `Driver.displayName` is a merchant-scoped alias, and neither value is
+  synchronized or backfilled into the other.
 - The app owns driver-facing UX, native permission prompts, SecureStore token
   handling, app-side offline retry/discard behavior, and mobile release evidence
   runbooks. It does not own Shopify data, route assignment authority,
@@ -37,9 +40,9 @@ environment values, or release artifacts from the target repository.
   consent records, driver events, proof-media metadata/storage contracts, and
   cleanup evidence. The driver app must use the server driver APIs rather than
   Shopify APIs directly.
-- Future app-tab server work should be exposed as delivery API contracts before
-  the app treats route history, earnings, profile update, or account deletion as
-  live server-backed features.
+- Account profile name updates use the paired delivery API. Future route history,
+  earnings, or account deletion work must also be exposed as delivery API
+  contracts before the app treats those features as live.
 
 ## Do not store here
 
@@ -58,6 +61,7 @@ environment values, or release artifacts from the target repository.
 - Target repository README: <https://github.com/EVNSolution/clever-driver-app/blob/dev/README.md>
 - Product brief and scenario plan: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/project-brief.md>
 - App-side API/runtime flow: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/route-access-flow.md>
+- Driver account authentication and profile contract: <https://github.com/EVNSolution/clever-route-server/blob/main/apps/delivery-api/docs/api/driver-auth.md>
 - Release readiness and evidence gates: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/release-readiness.md>
 - Physical-device smoke runbook: <https://github.com/EVNSolution/clever-driver-app/blob/dev/docs/physical-device-smoke-runbook.md>
 - Expo app identity config: <https://github.com/EVNSolution/clever-driver-app/blob/dev/app.json>

--- a/docs/services/clever-shopify-app/index.md
+++ b/docs/services/clever-shopify-app/index.md
@@ -16,7 +16,7 @@ the target repository.
 | runtime_source | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/shopify-app> |
 | product_scope | Shopify embedded admin app for CLEVER merchants: order intake, delivery-date filtering, route planning, route detail, driver invite/access, and operational navigation surfaces |
 | naming_authority | <https://github.com/EVNSolution/shopify-clever/blob/main/NAMING.md> |
-| paired_delivery_api | <https://github.com/EVNSolution/shopify-clever/tree/main/apps/delivery-api> |
+| paired_delivery_api | <https://github.com/EVNSolution/clever-route-server/tree/main/apps/delivery-api> |
 | related_mobile_runtime | <https://github.com/EVNSolution/clever-driver-app> |
 | deploy_lineage | React Router Shopify embedded app, Prisma session storage, Shopify CLI config split for production/public and dev/custom-store runtimes |
 
@@ -28,6 +28,8 @@ the target repository.
 - The Shopify app owns merchant/admin UX, Shopify authentication/session storage,
   order synchronization entry points, route planning UI, driver invite/admin
   actions, and App Store review-facing behavior.
+- `Driver.displayName` is a merchant/store-scoped operational alias. It is not
+  the driver's phone-owned account name and must not update or backfill it.
 - The Shopify app must not become the long-term source of driver mobile runtime
   state. Driver identity, route assignment authority, driver bearer auth,
   proof-media metadata, and mobile driver APIs belong to the paired delivery API.


### PR DESCRIPTION
## Summary
- point the driver app and Shopify app at the current clever-route-server delivery API authority
- record the phone-owned global account name versus merchant-scoped Driver.displayName boundary
- replace stale delivery server source pointers without copying runtime contracts

## Authority
- Closes #26
- Project/change control: EVNSolution/clever-change-control#145
- Driver app: EVNSolution/clever-driver-app#124 / PR #125
- Delivery server: EVNSolution/clever-route-server#138 / PR #139

## Concurrent work gate
- done: no open PR overlaps this pointer update

## Validation
- git diff --check
- referenced clever-route-server files verified in the current main worktree
- no stale shopify-clever delivery-api pointer remains in the edited service documents
- no executable document test suite exists in this repository