### PR TITLE
Document Ready-first route execution lifecycle

### DIFF
--- a/docs/services/clever-delivery-server/index.md
+++ b/docs/services/clever-delivery-server/index.md
@@ -28,6 +28,10 @@ repository.
 - Admin-facing APIs cover delivery orders, route planning, route assignment,
   driver invite/access operations, and synchronization boundaries used by the
   Shopify embedded app.
+- Route execution starts at child creation: every created child is `Ready`
+  without driver, stop, or publish prerequisites. Driver assignment is
+  lifecycle-neutral; `ROUTE_STARTED` moves it to `In progress`, and
+  `ROUTE_COMPLETED` moves it to `Completed`.
 - Driver-facing APIs cover invite verification, bearer access, consent records,
   assigned-route reads, driver events, proof-media upload metadata/storage,
   scoped proof-media read access, scan rejection hooks, monitoring hooks, and

--- a/docs/services/clever-driver-app/index.md
+++ b/docs/services/clever-driver-app/index.md
@@ -36,6 +36,9 @@ environment values, or release artifacts from the target repository.
   handling, app-side offline retry/discard behavior, and mobile release evidence
   runbooks. It does not own Shopify data, route assignment authority,
   proof-media metadata persistence, or object-storage credentials.
+- Route lists use the server lifecycle labels `Ready`, `In progress`, and
+  `Completed`. Assignment does not advance status; the driver's explicit start
+  and completion actions record the corresponding lifecycle events.
 - The paired delivery API owns companies/shops, drivers, route assignments,
   consent records, driver events, proof-media metadata/storage contracts, and
   cleanup evidence. The driver app must use the server driver APIs rather than

--- a/docs/services/clever-shopify-app/index.md
+++ b/docs/services/clever-shopify-app/index.md
@@ -28,6 +28,9 @@ the target repository.
 - The Shopify app owns merchant/admin UX, Shopify authentication/session storage,
   order synchronization entry points, route planning UI, driver invite/admin
   actions, and App Store review-facing behavior.
+- The route admin surface shows every materialized child immediately and uses
+  `Ready`, `In progress`, and `Completed` as the canonical execution labels;
+  legacy pre-execution statuses are presented as `Ready`.
 - `Driver.displayName` is a merchant/store-scoped operational alias. It is not
   the driver's phone-owned account name and must not update or backfill it.
 - The Shopify app must not become the long-term source of driver mobile runtime


### PR DESCRIPTION
## Summary
- document Ready at child creation
- document assignment as lifecycle-neutral
- align server, driver app, and Shopify admin interpretation

## Traceability
- Closes #28
- EVNSolution/clever-change-control#225
- EVNSolution/clever-route-server#141
- EVNSolution/clever-driver-app#128
- EVNSolution/shopify-clever#65

## Verification
- git diff --check

## Context boundary
Only stable interpretation is stored here; implementation, schema, and release evidence remain in target repositories.