### PR TITLE
Document Shopify source ownership boundary

### DIFF
--- a/docs/services/clever-delivery-server/index.md
+++ b/docs/services/clever-delivery-server/index.md
@@ -28,6 +28,9 @@ repository.
 - Admin-facing APIs cover delivery orders, route planning, route assignment,
   driver invite/access operations, and synchronization boundaries used by the
   Shopify embedded app.
+- Shopify order and customer records are immutable upstream source data for
+  K-food and development stores. Synchronization is one-way from Shopify into
+  CLEVER, and operator corrections are stored only in the CLEVER database.
 - Route execution starts at child creation: every created child is `Ready`
   without driver, stop, or publish prerequisites. Driver assignment is
   lifecycle-neutral; `ROUTE_STARTED` moves it to `In progress`, and

--- a/docs/services/clever-shopify-app/index.md
+++ b/docs/services/clever-shopify-app/index.md
@@ -28,6 +28,11 @@ the target repository.
 - The Shopify app owns merchant/admin UX, Shopify authentication/session storage,
   order synchronization entry points, route planning UI, driver invite/admin
   actions, and App Store review-facing behavior.
+- Shopify order and customer integrations are query-only for K-food and
+  development stores. Operational corrections are written through the paired
+  delivery API to the CLEVER database, not back to Shopify. App-owned
+  `AppInstallation` metafields remain limited to application settings such as
+  departure location and do not store order or customer corrections.
 - The route admin surface shows every materialized child immediately and uses
   `Ready`, `In progress`, and `Completed` as the canonical execution labels;
   legacy pre-execution statuses are presented as `Ready`.


### PR DESCRIPTION
## Summary
- record Shopify order/customer records as immutable upstream source
- record CLEVER DB as the only operational correction target
- preserve the narrow app-owned settings metafield exception

## Validation
- git diff --check

Closes #30
Related: EVNSolution/clever-change-control#226, EVNSolution/clever-route-server#143, EVNSolution/shopify-clever#67
